### PR TITLE
feat(manifest): update manifest output for v8 manifest compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install GitHub CLI
-        run: |
-          brew update
-          brew install gh
       - name: Generate Release
         run: gh release create ${{github.ref_name}} --generate-notes
         env:

--- a/packages/manifest/README.md
+++ b/packages/manifest/README.md
@@ -45,15 +45,15 @@ This will generate two bundles called `preload` and `game` in the manifest file.
 - `createShortcuts` - Whether to create shortcuts for each bundle. Defaults to `false`. If enabled the manifest will try to create the shortest path for an asset. e.g.
 ```json
 {
-    "name": ["game/char.png", "game.png"],
-    "srcs": ["game/char.png"]
+    "alias": ["game/char.png", "game.png"],
+    "src": ["game/char.png"]
 }
 ```
 - `trimExtensions` - Whether to trim the extensions from the asset names. Defaults to `false`. If enabled the manifest will try to create the shortest path for an asset. e.g.
 ```json
 {
-    "name": ["game/char.png", "game/char"],
-    "srcs": ["game/char.png"]
+    "alias": ["game/char.png", "game/char"],
+    "src": ["game/char.png"]
 }
 ```
 - `defaultParser` - The default parser to use on a transformed asset

--- a/packages/manifest/src/pixi.ts
+++ b/packages/manifest/src/pixi.ts
@@ -12,8 +12,8 @@ export interface PixiManifest
 
 export interface PixiManifestEntry
 {
-    name: string | string[];
-    srcs: string | string[];
+    alias: string | string[];
+    src: string | string[];
     data?: {
         tags: Tags;
         [x: string]: any;
@@ -63,7 +63,7 @@ function finish(
     {
         const nameMap = new Map<PixiManifestEntry, string[]>();
 
-        bundles.forEach((bundle) => bundle.assets.forEach((asset) => nameMap.set(asset, asset.name as string[])));
+        bundles.forEach((bundle) => bundle.assets.forEach((asset) => nameMap.set(asset, asset.alias as string[])));
 
         const arrays = Array.from(nameMap.values());
         const sets = arrays.map((arr) => new Set(arr));
@@ -75,7 +75,7 @@ function finish(
             {
                 const names = nameMap.get(asset) as string[];
 
-                asset.name = uniqueArrays.find((arr) => arr.every((x) => names.includes(x))) as string[];
+                asset.alias = uniqueArrays.find((arr) => arr.every((x) => names.includes(x))) as string[];
             });
         });
     }
@@ -141,7 +141,7 @@ function collect(
                 };
             }
 
-            entry.name = getShortNames(entry.name, options);
+            entry.alias = getShortNames(entry.alias, options);
         });
         bundle.assets.push(...result);
     }
@@ -164,8 +164,8 @@ export function defaultPixiParser(tree: ChildTree, processor: Processor, _option
         const name = processor.trimOutputPath(file.name ?? file.paths[0]);
 
         const res: PixiManifestEntry =  {
-            name,
-            srcs: file.paths.map((path) => processor.trimOutputPath(path)),
+            alias: name,
+            src: file.paths.map((path) => processor.trimOutputPath(path)),
         };
 
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/packages/manifest/test/Manifest.test.ts
+++ b/packages/manifest/test/Manifest.test.ts
@@ -132,8 +132,8 @@ describe('Manifest', () =>
             name: 'bundle',
             assets: [
                 {
-                    name: ['bundle/json.json'],
-                    srcs: ['bundle/json.json'],
+                    alias: ['bundle/json.json'],
+                    src: ['bundle/json.json'],
                     data: {
                         tags: {
                             m: true,
@@ -141,8 +141,8 @@ describe('Manifest', () =>
                     },
                 },
                 {
-                    name: ['bundle/json.json5'],
-                    srcs: ['bundle/json.json5'],
+                    alias: ['bundle/json.json5'],
+                    src: ['bundle/json.json5'],
                     data: {
                         tags: {
                             m: true,
@@ -150,8 +150,8 @@ describe('Manifest', () =>
                     },
                 },
                 {
-                    name: ['bundle/sprite.png'],
-                    srcs: [
+                    alias: ['bundle/sprite.png'],
+                    src: [
                         'bundle/sprite@1x.png',
                         'bundle/sprite@0.5x.png',
                         'bundle/sprite@0.5x.webp',
@@ -164,8 +164,8 @@ describe('Manifest', () =>
                     },
                 },
                 {
-                    name: ['bundle/tps/tps-1.json'],
-                    srcs: [
+                    alias: ['bundle/tps/tps-1.json'],
+                    src: [
                         'bundle/tps/tps-1@1x.json',
                         'bundle/tps/tps-1@0.5x.json',
                     ],
@@ -177,8 +177,8 @@ describe('Manifest', () =>
                     },
                 },
                 {
-                    name: ['bundle/tps/tps-0.json'],
-                    srcs: [
+                    alias: ['bundle/tps/tps-0.json'],
+                    src: [
                         'bundle/tps/tps-0@1x.json',
                         'bundle/tps/tps-0@0.5x.json',
                     ],
@@ -195,24 +195,24 @@ describe('Manifest', () =>
             name: 'default',
             assets: [
                 {
-                    name: ['defaultFolder/1.mp3'],
-                    srcs: ['defaultFolder/1.mp3', 'defaultFolder/1.ogg'],
+                    alias: ['defaultFolder/1.mp3'],
+                    src: ['defaultFolder/1.mp3', 'defaultFolder/1.ogg'],
                 },
                 {
-                    name: ['defaultFolder/3.wav'],
-                    srcs: ['defaultFolder/3.mp3', 'defaultFolder/3.ogg'],
+                    alias: ['defaultFolder/3.wav'],
+                    src: ['defaultFolder/3.mp3', 'defaultFolder/3.ogg'],
                 },
                 {
-                    name: ['spine/dragon.json'],
-                    srcs: ['spine/dragon.json'],
+                    alias: ['spine/dragon.json'],
+                    src: ['spine/dragon.json'],
                 },
                 {
-                    name: ['spine/dragon.png'],
-                    srcs: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
+                    alias: ['spine/dragon.png'],
+                    src: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
                 },
                 {
-                    name: ['spine/dragon2.png'],
-                    srcs: [
+                    alias: ['spine/dragon2.png'],
+                    src: [
                         'spine/dragon2@1x.png',
                         'spine/dragon2@0.5x.png',
                         'spine/dragon2@0.5x.webp',
@@ -220,8 +220,8 @@ describe('Manifest', () =>
                     ],
                 },
                 {
-                    name: ['spine/dragon.atlas'],
-                    srcs: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
+                    alias: ['spine/dragon.atlas'],
+                    src: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
                     data: {
                         tags: {
                             spine: true,
@@ -335,21 +335,21 @@ describe('Manifest', () =>
             name: 'default',
             assets: [
                 {
-                    name: ['folder/json.json', 'json.json'],
-                    srcs: ['folder/json.json'],
+                    alias: ['folder/json.json', 'json.json'],
+                    src: ['folder/json.json'],
                 },
                 {
-                    name: ['folder/json.json5', 'json.json5'],
-                    srcs: ['folder/json.json5'],
+                    alias: ['folder/json.json5', 'json.json5'],
+                    src: ['folder/json.json5'],
                 },
                 {
-                    name: [
+                    alias: [
                         'folder/sprite.png',
                         'folder/sprite',
                         'sprite.png',
                         'sprite',
                     ],
-                    srcs: [
+                    src: [
                         'folder/sprite@1x.png',
                         'folder/sprite@0.5x.png',
                         'folder/sprite@0.5x.webp',
@@ -357,29 +357,29 @@ describe('Manifest', () =>
                     ],
                 },
                 {
-                    name: ['folder2/1.mp3', 'folder2/1'],
-                    srcs: ['folder2/1.mp3', 'folder2/1.ogg'],
+                    alias: ['folder2/1.mp3', 'folder2/1'],
+                    src: ['folder2/1.mp3', 'folder2/1.ogg'],
                 },
                 {
-                    name: ['folder2/folder3/1.mp3', 'folder2/folder3/1'],
-                    srcs: ['folder2/folder3/1.mp3', 'folder2/folder3/1.ogg'],
+                    alias: ['folder2/folder3/1.mp3', 'folder2/folder3/1'],
+                    src: ['folder2/folder3/1.mp3', 'folder2/folder3/1.ogg'],
                 },
                 {
-                    name: ['spine/dragon.json', 'dragon.json'],
-                    srcs: ['spine/dragon.json'],
+                    alias: ['spine/dragon.json', 'dragon.json'],
+                    src: ['spine/dragon.json'],
                 },
                 {
-                    name: ['spine/dragon.png', 'dragon.png'],
-                    srcs: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
+                    alias: ['spine/dragon.png', 'dragon.png'],
+                    src: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
                 },
                 {
-                    name: [
+                    alias: [
                         'spine/dragon2.png',
                         'spine/dragon2',
                         'dragon2.png',
                         'dragon2',
                     ],
-                    srcs: [
+                    src: [
                         'spine/dragon2@1x.png',
                         'spine/dragon2@0.5x.png',
                         'spine/dragon2@0.5x.webp',
@@ -387,8 +387,8 @@ describe('Manifest', () =>
                     ],
                 },
                 {
-                    name: ['spine/dragon.atlas', 'dragon.atlas'],
-                    srcs: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
+                    alias: ['spine/dragon.atlas', 'dragon.atlas'],
+                    src: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
                     data: {
                         tags: {
                             spine: true,
@@ -502,16 +502,16 @@ describe('Manifest', () =>
             name: 'default',
             assets: [
                 {
-                    name: ['folder/json.json', 'json.json'],
-                    srcs: ['folder/json.json'],
+                    alias: ['folder/json.json', 'json.json'],
+                    src: ['folder/json.json'],
                 },
                 {
-                    name: ['folder/json.json5', 'json.json5'],
-                    srcs: ['folder/json.json5'],
+                    alias: ['folder/json.json5', 'json.json5'],
+                    src: ['folder/json.json5'],
                 },
                 {
-                    name: ['folder/sprite.png', 'sprite.png'],
-                    srcs: [
+                    alias: ['folder/sprite.png', 'sprite.png'],
+                    src: [
                         'folder/sprite@1x.png',
                         'folder/sprite@0.5x.png',
                         'folder/sprite@0.5x.webp',
@@ -519,24 +519,24 @@ describe('Manifest', () =>
                     ],
                 },
                 {
-                    name: ['folder2/1.mp3'],
-                    srcs: ['folder2/1.mp3', 'folder2/1.ogg'],
+                    alias: ['folder2/1.mp3'],
+                    src: ['folder2/1.mp3', 'folder2/1.ogg'],
                 },
                 {
-                    name: ['folder2/folder3/1.mp3'],
-                    srcs: ['folder2/folder3/1.mp3', 'folder2/folder3/1.ogg'],
+                    alias: ['folder2/folder3/1.mp3'],
+                    src: ['folder2/folder3/1.mp3', 'folder2/folder3/1.ogg'],
                 },
                 {
-                    name: ['spine/dragon.json', 'dragon.json'],
-                    srcs: ['spine/dragon.json'],
+                    alias: ['spine/dragon.json', 'dragon.json'],
+                    src: ['spine/dragon.json'],
                 },
                 {
-                    name: ['spine/dragon.png', 'dragon.png'],
-                    srcs: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
+                    alias: ['spine/dragon.png', 'dragon.png'],
+                    src: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
                 },
                 {
-                    name: ['spine/dragon2.png', 'dragon2.png'],
-                    srcs: [
+                    alias: ['spine/dragon2.png', 'dragon2.png'],
+                    src: [
                         'spine/dragon2@1x.png',
                         'spine/dragon2@0.5x.png',
                         'spine/dragon2@0.5x.webp',
@@ -544,8 +544,8 @@ describe('Manifest', () =>
                     ],
                 },
                 {
-                    name: ['spine/dragon.atlas', 'dragon.atlas'],
-                    srcs: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
+                    alias: ['spine/dragon.atlas', 'dragon.atlas'],
+                    src: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
                     data: {
                         tags: {
                             spine: true,
@@ -659,19 +659,19 @@ describe('Manifest', () =>
             name: 'default',
             assets: [
                 {
-                    name: ['folder/json.json'],
-                    srcs: ['folder/json.json'],
+                    alias: ['folder/json.json'],
+                    src: ['folder/json.json'],
                 },
                 {
-                    name: ['folder/json.json5'],
-                    srcs: ['folder/json.json5'],
+                    alias: ['folder/json.json5'],
+                    src: ['folder/json.json5'],
                 },
                 {
-                    name: [
+                    alias: [
                         'folder/sprite.png',
                         'folder/sprite',
                     ],
-                    srcs: [
+                    src: [
                         'folder/sprite@1x.png',
                         'folder/sprite@0.5x.png',
                         'folder/sprite@0.5x.webp',
@@ -679,27 +679,27 @@ describe('Manifest', () =>
                     ],
                 },
                 {
-                    name: ['folder2/1.mp3', 'folder2/1'],
-                    srcs: ['folder2/1.mp3', 'folder2/1.ogg'],
+                    alias: ['folder2/1.mp3', 'folder2/1'],
+                    src: ['folder2/1.mp3', 'folder2/1.ogg'],
                 },
                 {
-                    name: ['folder2/folder3/1.mp3', 'folder2/folder3/1'],
-                    srcs: ['folder2/folder3/1.mp3', 'folder2/folder3/1.ogg'],
+                    alias: ['folder2/folder3/1.mp3', 'folder2/folder3/1'],
+                    src: ['folder2/folder3/1.mp3', 'folder2/folder3/1.ogg'],
                 },
                 {
-                    name: ['spine/dragon.json'],
-                    srcs: ['spine/dragon.json'],
+                    alias: ['spine/dragon.json'],
+                    src: ['spine/dragon.json'],
                 },
                 {
-                    name: ['spine/dragon.png'],
-                    srcs: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
+                    alias: ['spine/dragon.png'],
+                    src: ['spine/dragon@1x.png', 'spine/dragon@0.5x.png', 'spine/dragon@0.5x.webp', 'spine/dragon@1x.webp'],
                 },
                 {
-                    name: [
+                    alias: [
                         'spine/dragon2.png',
                         'spine/dragon2',
                     ],
-                    srcs: [
+                    src: [
                         'spine/dragon2@1x.png',
                         'spine/dragon2@0.5x.png',
                         'spine/dragon2@0.5x.webp',
@@ -707,8 +707,8 @@ describe('Manifest', () =>
                     ],
                 },
                 {
-                    name: ['spine/dragon.atlas'],
-                    srcs: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
+                    alias: ['spine/dragon.atlas'],
+                    src: ['spine/dragon@1x.atlas', 'spine/dragon@0.5x.atlas'],
                     data: {
                         tags: {
                             spine: true,

--- a/packages/webfont/test/Webfont.test.ts
+++ b/packages/webfont/test/Webfont.test.ts
@@ -272,8 +272,8 @@ describe('Webfont', () =>
             name: 'default',
             assets: [
                 {
-                    name: ['defaultFolder/ttf.ttf'],
-                    srcs: ['defaultFolder/ttf.woff2'],
+                    alias: ['defaultFolder/ttf.ttf'],
+                    src: ['defaultFolder/ttf.woff2'],
                     data: {
                         tags: {
                             wf: true,
@@ -281,8 +281,8 @@ describe('Webfont', () =>
                     }
                 },
                 {
-                    name: ['sdfFolder/ttf.ttf'],
-                    srcs: ['sdfFolder/ttf.fnt'],
+                    alias: ['sdfFolder/ttf.ttf'],
+                    src: ['sdfFolder/ttf.fnt'],
                     data: {
                         tags: {
                             sdf: true,


### PR DESCRIPTION
BREAKING CHANGE: renames `name` and `srcs` to `alias` and `src` for compatibility with pixi v8 which removed these options