### PR TITLE
fix: texture-packer should include format of image file in spritesheet json file's name

### DIFF
--- a/packages/manifest/test/Manifest.test.ts
+++ b/packages/manifest/test/Manifest.test.ts
@@ -166,8 +166,8 @@ describe('Manifest', () =>
                 {
                     alias: ['bundle/tps/tps-1.json'],
                     src: [
-                        'bundle/tps/tps-1@1x.json',
-                        'bundle/tps/tps-1@0.5x.json',
+                        'bundle/tps/tps-1@1x.png.json',
+                        'bundle/tps/tps-1@0.5x.png.json',
                     ],
                     data: {
                         tags: {
@@ -179,8 +179,8 @@ describe('Manifest', () =>
                 {
                     alias: ['bundle/tps/tps-0.json'],
                     src: [
-                        'bundle/tps/tps-0@1x.json',
-                        'bundle/tps/tps-0@0.5x.json',
+                        'bundle/tps/tps-0@1x.png.json',
+                        'bundle/tps/tps-0@0.5x.png.json',
                     ],
                     data: {
                         tags: {

--- a/packages/texture-packer/test/TP.test.ts
+++ b/packages/texture-packer/test/TP.test.ts
@@ -57,7 +57,7 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        const sheet1 = readJSONSync(`${outputDir}/sprites/sprites@1x.json`);
+        const sheet1 = readJSONSync(`${outputDir}/sprites/sprites@1x.png.json`);
 
         const expectedSize =  {
             w: 560,
@@ -66,7 +66,7 @@ describe('Texture Packer', () =>
 
         expect(sheet1.meta.size).toEqual(expectedSize);
 
-        const sheet2Exists = existsSync(`${outputDir}/sprites/sprites-1@1x.json`);
+        const sheet2Exists = existsSync(`${outputDir}/sprites/sprites-1@1x.png.json`);
 
         expect(sheet2Exists).toBe(false);
     });
@@ -95,8 +95,8 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        const sheet1 = readJSONSync(`${outputDir}/sprites/sprites-0@1x.json`);
-        const sheet2 = readJSONSync(`${outputDir}/sprites/sprites-1@1x.json`);
+        const sheet1 = readJSONSync(`${outputDir}/sprites/sprites-0@1x.png.json`);
+        const sheet2 = readJSONSync(`${outputDir}/sprites/sprites-1@1x.png.json`);
 
         expect(sheet1.meta.size.w).toBeLessThanOrEqual(size);
         expect(sheet1.meta.size.h).toBeLessThanOrEqual(size);
@@ -130,7 +130,7 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        const json = existsSync(`${outputDir}/sprites/something@1x.json`);
+        const json = existsSync(`${outputDir}/sprites/something@1x.png.json`);
         const png = existsSync(`${outputDir}/sprites/something@1x.png`);
 
         expect(png).toBe(true);
@@ -159,16 +159,16 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        expect(existsSync(`${outputDir}/sprites/sprites@0.5x.json`)).toBe(true);
-        expect(existsSync(`${outputDir}/sprites/sprites@1x.json`)).toBe(true);
-        expect(existsSync(`${outputDir}/sprites/sprites@2x.json`)).toBe(true);
+        expect(existsSync(`${outputDir}/sprites/sprites@0.5x.png.json`)).toBe(true);
+        expect(existsSync(`${outputDir}/sprites/sprites@1x.png.json`)).toBe(true);
+        expect(existsSync(`${outputDir}/sprites/sprites@2x.png.json`)).toBe(true);
         expect(existsSync(`${outputDir}/sprites/sprites@0.5x.png`)).toBe(true);
         expect(existsSync(`${outputDir}/sprites/sprites@1x.png`)).toBe(true);
         expect(existsSync(`${outputDir}/sprites/sprites@2x.png`)).toBe(true);
 
-        const sheet1Data = readJSONSync(`${outputDir}/sprites/sprites@1x.json`);
-        const sheet2Data = readJSONSync(`${outputDir}/sprites/sprites@2x.json`);
-        const sheet3Data = readJSONSync(`${outputDir}/sprites/sprites@0.5x.json`);
+        const sheet1Data = readJSONSync(`${outputDir}/sprites/sprites@1x.png.json`);
+        const sheet2Data = readJSONSync(`${outputDir}/sprites/sprites@2x.png.json`);
+        const sheet3Data = readJSONSync(`${outputDir}/sprites/sprites@0.5x.png.json`);
 
         expect(sheet2Data.frames['sprite0.png'].frame).toEqual({ x: 2, y: 2, w: 136, h: 196 });
         expect(sheet2Data.meta.size).toEqual({ w: 560, h: 480 });
@@ -241,7 +241,7 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        const sheet1 = readJSONSync(`${outputDir}/sprites/sprites@1x.json`);
+        const sheet1 = readJSONSync(`${outputDir}/sprites/sprites@1x.png.json`);
 
         const expectedSize =  {
             w: 560,
@@ -250,7 +250,7 @@ describe('Texture Packer', () =>
 
         expect(sheet1.meta.size).toEqual(expectedSize);
 
-        const sheet2Exists = existsSync(`${outputDir}/sprites/sprites-1@1x.json`);
+        const sheet2Exists = existsSync(`${outputDir}/sprites/sprites-1@1x.png.json`);
 
         expect(sheet2Exists).toBe(false);
     });
@@ -273,8 +273,8 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        const sheet1 = existsSync(`${outputDir}/sprites/sprites@1x.json`);
-        const sheet2 = existsSync(`${outputDir}/sprites/sprites@0.5x.json`);
+        const sheet1 = existsSync(`${outputDir}/sprites/sprites@1x.png.json`);
+        const sheet2 = existsSync(`${outputDir}/sprites/sprites@0.5x.png.json`);
 
         expect(sheet1).toBe(true);
         expect(sheet2).toBe(true);
@@ -285,7 +285,7 @@ describe('Texture Packer', () =>
             h: 480 / 2,
         };
 
-        const sheetJson = readJSONSync(`${outputDir}/sprites/sprites@0.5x.json`);
+        const sheetJson = readJSONSync(`${outputDir}/sprites/sprites@0.5x.png.json`);
 
         expect(sheetJson.meta.size).toEqual(expectedSize);
     });
@@ -336,9 +336,9 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        const sheet1 = existsSync(`${outputDir}/sprites/sprites/sprites@1x.json`);
-        const sheet2 = existsSync(`${outputDir}/sprites/sprites/sprites@0.5x.json`);
-        const sheet3 = existsSync(`${outputDir}/sprites/sprites/sprites@2x.json`);
+        const sheet1 = existsSync(`${outputDir}/sprites/sprites/sprites@1x.png.json`);
+        const sheet2 = existsSync(`${outputDir}/sprites/sprites/sprites@0.5x.png.json`);
+        const sheet3 = existsSync(`${outputDir}/sprites/sprites/sprites@2x.png.json`);
 
         expect(sheet1).toBe(true);
         expect(sheet2).toBe(false);
@@ -385,7 +385,7 @@ describe('Texture Packer', () =>
 
         await assetpack.run();
 
-        const sheet1 = existsSync(`${outputDir}/sprites/sprites@1x.json`);
+        const sheet1 = existsSync(`${outputDir}/sprites/sprites@1x.jpg.json`);
         const sheet2 = existsSync(`${outputDir}/sprites/sprites@1x.jpg`);
         const sheet3 = existsSync(`${outputDir}/sprites/sprites@1x.png`);
 


### PR DESCRIPTION
This PR makes it so that `texture-packer` includes the image format of the underlying spritesheet within the file name of the spritesheet's json file.

For example, if it would previously output `my-spritesheet@2x.json`, it now outputs `my-spritesheet@2x.png.json`

### Rationale
Including the underlying image format as part of a json spritesheet's filename appears to be required by convention in Pixi's spritesheet loader [(link to Pixi.js documentation).](https://arc.net/l/quote/ijmzcyot)

I ran into an issue where I was generating spritesheets with 3 different resolutions (e.g. `@1x`, `@2x`, `@3x`) but when loading them into Pixi, all resolutions would be ignored and the first spritesheet in the list (regardless of what resolution it was) would be loaded.

After debugging the execution of both the Pixi loader and AssetPack, I determined the source of the problem: Pixi's loader does not attempt to parse the file names a spritesheet to extract metadata such as resolution if the spritesheet JSON file's filename does not adhere to the following filename convention: `my-spritesheet{resolution}.{imageFormat}.json`

### Solution
I changed AssetPack's `texture-packer` to include the underlying texture file format in the spritesheet JSON file's filename.

I cannot see a reason why it should not be there, and I think the lack of it was by accidental omission rather than intentional. As it currently stands, spritesheets generated with AssetPack cannot be loaded correctly by Pixi when they contain multiple resolutions.


@Zyie please consider merging this PR or let me know how I could improve it.