### PR TITLE
Compress bypass option

### DIFF
--- a/packages/assetpack/src/image/compress.ts
+++ b/packages/assetpack/src/image/compress.ts
@@ -2,6 +2,7 @@ import sharp from 'sharp';
 import { checkExt, createNewAssetAt } from '../core/index.js';
 import { compressSharp } from './utils/compressSharp.js';
 import { resolveOptions } from './utils/resolveOptions.js';
+import { BYPASS } from './constants.js';
 
 import type { AvifOptions, JpegOptions, PngOptions, WebpOptions } from 'sharp';
 import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
@@ -13,10 +14,10 @@ type CompressPngOptions = Omit<PngOptions, 'force'>;
 
 export interface CompressOptions extends PluginOptions
 {
-    png?: CompressPngOptions | boolean;
-    webp?: CompressWebpOptions | boolean;
-    avif?: CompressAvifOptions | boolean;
-    jpg?: CompressJpgOptions | boolean;
+    png?: CompressPngOptions | boolean | typeof BYPASS;
+    webp?: CompressWebpOptions | boolean | typeof BYPASS;
+    avif?: CompressAvifOptions | boolean | typeof BYPASS;
+    jpg?: CompressJpgOptions | boolean | typeof BYPASS;
 }
 
 export interface CompressImageData
@@ -97,6 +98,11 @@ export function compress(options: CompressOptions = {}): AssetPipe<CompressOptio
 
                     return newAsset;
                 });
+
+                // bypass source asset
+                if (options[asset.extension.slice(1) as keyof CompressOptions] === BYPASS) {
+                    newAssets.push(asset);
+                }
 
                 const promises = processedImages.map((image, i) => image.sharpImage.toBuffer().then((buffer) =>
                 {

--- a/packages/assetpack/src/image/constants.ts
+++ b/packages/assetpack/src/image/constants.ts
@@ -1,0 +1,1 @@
+export const BYPASS = 'bypass';

--- a/packages/assetpack/src/image/utils/compressSharp.ts
+++ b/packages/assetpack/src/image/utils/compressSharp.ts
@@ -1,5 +1,8 @@
+import { BYPASS } from '../constants.js';
+
 import type { AvifOptions, JpegOptions, PngOptions, WebpOptions } from 'sharp';
 import type { CompressImageData, CompressOptions } from '../compress.js';
+
 
 export async function compressSharp(
     image: CompressImageData,
@@ -10,7 +13,7 @@ export async function compressSharp(
 
     const sharpImage = image.sharpImage;
 
-    if (image.format === '.png' && options.png)
+    if (image.format === '.png' && options.png && options.png !== BYPASS)
     {
         compressed.push({
             format: '.png',
@@ -19,7 +22,7 @@ export async function compressSharp(
         });
     }
 
-    if (options.webp)
+    if (options.webp && options.webp !== BYPASS)
     {
         compressed.push({
             format: '.webp',
@@ -28,7 +31,7 @@ export async function compressSharp(
         });
     }
 
-    if (((image.format === '.jpg') || (image.format === '.jpeg')) && options.jpg)
+    if (((image.format === '.jpg') || (image.format === '.jpeg')) && options.jpg && options.jpg !== BYPASS)
     {
         compressed.push({
             format: '.jpg',
@@ -37,7 +40,7 @@ export async function compressSharp(
         });
     }
 
-    if (options.avif)
+    if (options.avif && options.avif !== BYPASS)
     {
         compressed.push({
             format: '.avif',

--- a/packages/assetpack/test/image/Compress.test.ts
+++ b/packages/assetpack/test/image/Compress.test.ts
@@ -8,7 +8,7 @@ const pkg = 'image';
 
 describe('Compress', () =>
 {
-    it('should compress png', async () =>
+    it('should compress png and bypass jpg', async () =>
     {
         const testName = 'compress-png';
         const inputDir = getInputDir(pkg, testName);
@@ -40,7 +40,7 @@ describe('Compress', () =>
                     png: true,
                     webp: true,
                     avif: true,
-                    jpg: true,
+                    jpg: 'bypass',
                 }),
             ]
         });
@@ -56,7 +56,7 @@ describe('Compress', () =>
         expect(existsSync(`${outputDir}/testJpg.png`)).toBe(false);
     });
 
-    it('should compress png with 1 plugin', async () =>
+    it('should compress png and bypass jpg with 1 plugin', async () =>
     {
         const testName = 'compress-png-1-plugin';
         const inputDir = getInputDir(pkg, testName);
@@ -86,7 +86,7 @@ describe('Compress', () =>
                 compress({
                     png: true,
                     webp: true,
-                    jpg: true,
+                    jpg: 'bypass',
                     avif: true,
                 }),
             ],

--- a/packages/docs/docs/guide/pipes/compress.mdx
+++ b/packages/docs/docs/guide/pipes/compress.mdx
@@ -31,12 +31,12 @@ export default {
 
 ## API
 
-| Option | Type              | Description                                                                                                          |
-| ------ | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
-| jpg    | `object \| false` | Any settings supported by [sharp jpeg](https://sharp.pixelplumbing.com/api-output#jpeg).                             |
-| png    | `object \| false` | Any settings supported by [sharp png](https://sharp.pixelplumbing.com/api-output#png).                               |
-| webp   | `object \| false` | Any settings supported by [sharp webp](https://sharp.pixelplumbing.com/api-output#webp).                             |
-| avif   | `object \| false` | Any settings supported by [sharp avif](https://sharp.pixelplumbing.com/api-output#avif). <br /> Defaults to `false`. |
+| Option | Type                          | Description                                                              |
+|--------|-------------------------------|--------------------------------------------------------------------------|
+| jpg    | `object \| false \| 'bypass'` | Any settings supported by [sharp jpeg](https://sharp.pixelplumbing.com/api-output#jpeg).                             |
+| png    | `object \| false \| 'bypass'` | Any settings supported by [sharp png](https://sharp.pixelplumbing.com/api-output#png).                               |
+| webp   | `object \| false \| 'bypass'` | Any settings supported by [sharp webp](https://sharp.pixelplumbing.com/api-output#webp).                             |
+| avif   | `object \| false \| 'bypass'` | Any settings supported by [sharp avif](https://sharp.pixelplumbing.com/api-output#avif). <br /> Defaults to `false`. |
 
 ## Tags
 


### PR DESCRIPTION
Add bypass options to the compress plugin. 
Bypassed assets are copied without any processing (this is the same behavior as in version <1.0 when the option was set to false).