### PR TITLE
fix: compress plugin not outputting original image

### DIFF
--- a/packages/assetpack/src/image/compress.ts
+++ b/packages/assetpack/src/image/compress.ts
@@ -63,7 +63,7 @@ export function compress(options: CompressOptions = {}): AssetPipe<CompressOptio
         },
         test(asset: Asset, options)
         {
-            return options && checkExt(asset.path, '.png', '.jpg', '.jpeg') && !asset.allMetaData[this.tags!.nc];
+            return compress && options && checkExt(asset.path, '.png', '.jpg', '.jpeg') && !asset.allMetaData[this.tags!.nc];
         },
         async transform(asset: Asset, options)
         {
@@ -97,6 +97,12 @@ export function compress(options: CompressOptions = {}): AssetPipe<CompressOptio
 
                     return newAsset;
                 });
+
+                // ensure that the original image is passed through if it is not compressed by png/jpg options
+                if ((image.format === '.png' && !options.png) || (((image.format === '.jpg') || (image.format === '.jpeg')) && !options.jpg))
+                {
+                    newAssets.push(asset);
+                }
 
                 const promises = processedImages.map((image, i) => image.sharpImage.toBuffer().then((buffer) =>
                 {

--- a/packages/assetpack/src/image/compress.ts
+++ b/packages/assetpack/src/image/compress.ts
@@ -63,7 +63,7 @@ export function compress(options: CompressOptions = {}): AssetPipe<CompressOptio
         },
         test(asset: Asset, options)
         {
-            return compress && options && checkExt(asset.path, '.png', '.jpg', '.jpeg') && !asset.allMetaData[this.tags!.nc];
+            return options && checkExt(asset.path, '.png', '.jpg', '.jpeg') && !asset.allMetaData[this.tags!.nc];
         },
         async transform(asset: Asset, options)
         {

--- a/packages/assetpack/test/image/Compress.test.ts
+++ b/packages/assetpack/test/image/Compress.test.ts
@@ -84,9 +84,9 @@ describe('Compress', () =>
             cache: false,
             pipes: [
                 compress({
-                    png: true,
+                    png: false,
                     webp: true,
-                    jpg: true,
+                    jpg: false,
                     avif: true,
                 }),
             ],


### PR DESCRIPTION
alternative to #73

the compress plugin should copy over the original image if png/jpg is set to false, otherwise the image is lost