### PR TITLE
chore: fix typo in Texture Packer Compress

### DIFF
--- a/packages/docs/docs/guide/pipes/texture-packer.mdx
+++ b/packages/docs/docs/guide/pipes/texture-packer.mdx
@@ -88,7 +88,7 @@ To compress the texture atlases you can use the `texturePackerCompress` plugin. 
 
 ```js
 import { compress } from "@assetpack/core/image";
-import { compress } from "@assetpack/core/texture-packer";
+import { texturePackerCompress } from "@assetpack/core/texture-packer";
 
 // these options are the default values, all options shown here are optional
 const options = {


### PR DESCRIPTION
In [Texture Packer Compress](https://pixijs.io/assetpack/docs/guide/pipes/texture-packer/#texture-packer-compress) document, there's a typo in the code. It should be:
`import { texturePackerCompress } from "@assetpack/core/texture-packer";`