### PR TITLE
feat: allow tags to be added manifest data directly

### DIFF
--- a/packages/assetpack/src/core/Asset.ts
+++ b/packages/assetpack/src/core/Asset.ts
@@ -31,6 +31,7 @@ export class Asset
     metaData: Record<string, any> = {};
     inheritedMetaData: Record<string, any> = {};
     transformData: Record<string, any> = {};
+    manifestData: Record<string, any> = {};
 
     settings?: Record<string, any>;
 
@@ -251,6 +252,23 @@ export class Asset
         for (let i = 0; i < this.children.length; i++)
         {
             this.children[i].releaseChildrenBuffers();
+        }
+    }
+
+    /**
+     * Update the manifest data with certain keys from the metaData
+     * @param keys - keys to apply from the metaData to the manifestData
+     */
+    applyManifestData(keys: string[])
+    {
+        for (let i = 0; i < keys.length; i++)
+        {
+            const key = keys[i];
+
+            if (this.metaData[key] !== undefined)
+            {
+                this.manifestData[key] = this.metaData[key];
+            }
         }
     }
 }

--- a/packages/assetpack/src/core/Asset.ts
+++ b/packages/assetpack/src/core/Asset.ts
@@ -30,7 +30,6 @@ export class Asset
 
     metaData: Record<string, any> = {};
     inheritedMetaData: Record<string, any> = {};
-    private _allMetaData: Record<string, any> = {};
     transformData: Record<string, any> = {};
 
     settings?: Record<string, any>;
@@ -63,7 +62,6 @@ export class Asset
         asset.parent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
-        asset._allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
         asset.transformData = { ...this.transformData, ...asset.transformData };
     }
 
@@ -87,7 +85,6 @@ export class Asset
         asset.transformParent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
-        asset._allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
         asset.transformData = { ...this.transformData, ...asset.transformData };
 
         asset.settings = this.settings;

--- a/packages/assetpack/src/core/Asset.ts
+++ b/packages/assetpack/src/core/Asset.ts
@@ -31,7 +31,6 @@ export class Asset
     metaData: Record<string, any> = {};
     inheritedMetaData: Record<string, any> = {};
     transformData: Record<string, any> = {};
-    manifestData: Record<string, any> = {};
 
     settings?: Record<string, any>;
 
@@ -256,20 +255,38 @@ export class Asset
     }
 
     /**
-     * Update the manifest data with certain keys from the metaData
-     * @param keys - keys to apply from the metaData to the manifestData
+     * Get the public meta data for this asset
+     * This will exclude any internal data
      */
-    applyManifestData(keys: string[])
+    getPublicMetaData(internalPipeData: Record<string, any>)
     {
-        for (let i = 0; i < keys.length; i++)
+        const internalKeys = new Set(Object.keys(internalPipeData));
+        const metaData = Object.keys(this.allMetaData).reduce((result: Record<string, any>, key) =>
         {
-            const key = keys[i];
-
-            if (this.metaData[key] !== undefined)
+            if (!internalKeys.has(key))
             {
-                this.manifestData[key] = this.metaData[key];
+                result[key] = this.allMetaData[key];
             }
-        }
+
+            return result;
+        }, {} as Record<string, any>);
+
+        return metaData;
+    }
+
+    getInternalMetaData(internalPipeData: Record<string, any>)
+    {
+        const res: Record<string, any> = {};
+
+        Object.keys(internalPipeData).forEach((key) =>
+        {
+            if (this.allMetaData[key])
+            {
+                res[key] = this.allMetaData[key];
+            }
+        });
+
+        return res;
     }
 }
 

--- a/packages/assetpack/src/core/Asset.ts
+++ b/packages/assetpack/src/core/Asset.ts
@@ -30,7 +30,7 @@ export class Asset
 
     metaData: Record<string, any> = {};
     inheritedMetaData: Record<string, any> = {};
-    allMetaData: Record<string, any> = {};
+    private _allMetaData: Record<string, any> = {};
     transformData: Record<string, any> = {};
 
     settings?: Record<string, any>;
@@ -63,7 +63,7 @@ export class Asset
         asset.parent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
-        asset.allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
+        asset._allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
         asset.transformData = { ...this.transformData, ...asset.transformData };
     }
 
@@ -87,10 +87,15 @@ export class Asset
         asset.transformParent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
-        asset.allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
+        asset._allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
         asset.transformData = { ...this.transformData, ...asset.transformData };
 
         asset.settings = this.settings;
+    }
+
+    get allMetaData()
+    {
+        return { ...this.inheritedMetaData, ...this.metaData };
     }
 
     get state()

--- a/packages/assetpack/src/core/pipes/AssetPipe.ts
+++ b/packages/assetpack/src/core/pipes/AssetPipe.ts
@@ -17,7 +17,7 @@ export type DeepRequired<T> = T extends Primitive
     };
 export interface PluginOptions {}
 
-export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = string>
+export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = string, DATA_TAGS extends string = string>
 {
     /** Whether the process runs on a folder */
     folder?: boolean;
@@ -30,6 +30,12 @@ export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = st
 
     /** Tags that can be used to control the plugin */
     tags?: Record<TAGS, string>;
+
+    /**
+     * Any tags here will be placed in the manifests `data` object
+     * This can be used to pass data to loaders more easily
+     */
+    dataTags?: Record<DATA_TAGS, string>;
 
     /**
      * Called once at the start.

--- a/packages/assetpack/src/core/pipes/AssetPipe.ts
+++ b/packages/assetpack/src/core/pipes/AssetPipe.ts
@@ -17,7 +17,7 @@ export type DeepRequired<T> = T extends Primitive
     };
 export interface PluginOptions {}
 
-export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = string, DATA_TAGS extends string = string>
+export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = string, INTERNAL_TAGS extends string = string>
 {
     /** Whether the process runs on a folder */
     folder?: boolean;
@@ -32,10 +32,9 @@ export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = st
     tags?: Record<TAGS, string>;
 
     /**
-     * Any tags here will be placed in the manifests `data` object
-     * This can be used to pass data to loaders more easily
+     * Any tags here will not be placed in the manifest data.
      */
-    dataTags?: Record<DATA_TAGS, string>;
+    internalTags?: Record<INTERNAL_TAGS, string>;
 
     /**
      * Called once at the start.

--- a/packages/assetpack/src/core/pipes/PipeSystem.ts
+++ b/packages/assetpack/src/core/pipes/PipeSystem.ts
@@ -28,6 +28,11 @@ export class PipeSystem
 
     assetSettings: AssetSettings[] = [];
 
+    internalMetaData: Record<string, any> = {
+        copy: 'copy',
+        ignore: 'ignore',
+    };
+
     constructor(options: PipeSystemOptions)
     {
         const pipes = [];
@@ -49,6 +54,7 @@ export class PipeSystem
         options.pipes.flat().forEach((pipe) =>
         {
             this.pipeHash[pipe.name] = pipe;
+            this.internalMetaData = { ...this.internalMetaData, ...Object.values(pipe.internalTags ?? pipe.tags ?? {}).reduce((acc, tag) => ({ ...acc, [tag]: true }), {}) };
         });
 
         this.pipes = pipes;
@@ -88,8 +94,6 @@ export class PipeSystem
         {
             asset.transformName = pipe.name;
             asset.transformChildren = [];
-            // apply the dataTags of the pipe to the asset so it can be used by pixi and other loaders
-            asset.applyManifestData(Object.values(pipe.dataTags ?? {}));
 
             const assets = await pipe.transform(asset, options, this);
 

--- a/packages/assetpack/src/core/pipes/PipeSystem.ts
+++ b/packages/assetpack/src/core/pipes/PipeSystem.ts
@@ -88,6 +88,8 @@ export class PipeSystem
         {
             asset.transformName = pipe.name;
             asset.transformChildren = [];
+            // apply the dataTags of the pipe to the asset so it can be used by pixi and other loaders
+            asset.applyManifestData(Object.values(pipe.dataTags ?? {}));
 
             const assets = await pipe.transform(asset, options, this);
 

--- a/packages/assetpack/src/image/compress.ts
+++ b/packages/assetpack/src/image/compress.ts
@@ -137,8 +137,8 @@ export function compress(options: CompressOptions = {}): AssetPipe<CompressOptio
                 if ((image.format === '.png' && !options.png) || (((image.format === '.jpg') || (image.format === '.jpeg')) && !options.jpg))
                 {
                     newAssets.push(asset);
-
                 }
+
                 return newAssets;
             }
             catch (error)

--- a/packages/assetpack/src/image/compress.ts
+++ b/packages/assetpack/src/image/compress.ts
@@ -67,7 +67,7 @@ export function compress(options: CompressOptions = {}): AssetPipe<CompressOptio
         },
         async transform(asset: Asset, options)
         {
-            const shouldCompress = compress && !asset.metaData.nc;
+            const shouldCompress = compress && !asset.metaData[this.tags!.nc];
 
             if (!shouldCompress)
             {

--- a/packages/assetpack/src/image/utils/compressGpuTextures.ts
+++ b/packages/assetpack/src/image/utils/compressGpuTextures.ts
@@ -21,11 +21,11 @@ export async function compressGpuTextures(
     options: CompressOptions,
 ): Promise<CompressImageDataResult[]>
 {
-    let compressed: CompressImageDataResult[] = [];
+    let compressed: (Partial<CompressImageDataResult> & {image: Promise<string>})[] = [];
 
     if (!options.astc && !options.bc7 && !options.basis)
     {
-        return compressed;
+        return compressed as CompressImageDataResult[];
     }
 
     const tmpDir = await fs.mkdtemp(join(tmpdir(), 'assetpack-tex-'));
@@ -87,7 +87,7 @@ export async function compressGpuTextures(
         await fs.rm(tmpDir, { recursive: true, force: true });
     }
 
-    return compressed;
+    return compressed as CompressImageDataResult[];
 }
 
 async function adjustImageSize(sharpImage: sharp.Sharp, imagePath: string): Promise<string>

--- a/packages/assetpack/src/manifest/pixiManifest.ts
+++ b/packages/assetpack/src/manifest/pixiManifest.ts
@@ -143,7 +143,8 @@ function collectAssets(
                 .map((finalAsset) => path.relative(outputPath, finalAsset.path))
                 .sort((a, b) => b.localeCompare(a)),
             data:  options.includeMetaData ? {
-                tags: asset.allMetaData
+                tags: asset.allMetaData,
+                ...asset.manifestData
             } : undefined
         });
     }

--- a/packages/assetpack/src/webfont/sdf.ts
+++ b/packages/assetpack/src/webfont/sdf.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import generateBMFont from 'msdf-bmfont-xml';
-import { checkExt, createNewAssetAt, stripTags } from '../core/index.js';
+import { checkExt, createNewAssetAt, path, stripTags } from '../core/index.js';
 
 import type { BitmapFontOptions } from 'msdf-bmfont-xml';
 import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
@@ -14,7 +14,7 @@ export interface SDFFontOptions extends PluginOptions
 
 function signedFont(
     defaultOptions: SDFFontOptions
-): AssetPipe<SDFFontOptions, 'font' | 'nc' | 'fix'>
+): AssetPipe<SDFFontOptions, 'font' | 'nc' | 'fix', 'family'>
 {
     return {
         folder: false,
@@ -25,6 +25,9 @@ function signedFont(
             nc: 'nc',
             fix: 'fix',
         },
+        dataTags: {
+            family: 'family',
+        },
         test(asset: Asset)
         {
             return asset.allMetaData[this.tags!.font] && checkExt(asset.path, '.ttf');
@@ -33,6 +36,8 @@ function signedFont(
         {
             const newFileName = stripTags(asset.filename.replace(/\.(ttf)$/i, ''));
 
+            // set the family name to the filename if it doesn't exist
+            asset.manifestData.family = asset.metaData.family ?? path.trimExt(asset.filename);
             const { font, textures } = await GenerateFont(asset.path, {
                 ...options.font,
                 filename: newFileName,

--- a/packages/assetpack/src/webfont/sdf.ts
+++ b/packages/assetpack/src/webfont/sdf.ts
@@ -14,7 +14,7 @@ export interface SDFFontOptions extends PluginOptions
 
 function signedFont(
     defaultOptions: SDFFontOptions
-): AssetPipe<SDFFontOptions, 'font' | 'nc' | 'fix', 'family'>
+): AssetPipe<SDFFontOptions, 'font' | 'nc' | 'fix'>
 {
     return {
         folder: false,
@@ -25,9 +25,6 @@ function signedFont(
             nc: 'nc',
             fix: 'fix',
         },
-        dataTags: {
-            family: 'family',
-        },
         test(asset: Asset)
         {
             return asset.allMetaData[this.tags!.font] && checkExt(asset.path, '.ttf');
@@ -37,7 +34,7 @@ function signedFont(
             const newFileName = stripTags(asset.filename.replace(/\.(ttf)$/i, ''));
 
             // set the family name to the filename if it doesn't exist
-            asset.manifestData.family = asset.metaData.family ?? path.trimExt(asset.filename);
+            asset.metaData.family ??= path.trimExt(asset.filename);
             const { font, textures } = await GenerateFont(asset.path, {
                 ...options.font,
                 filename: newFileName,

--- a/packages/assetpack/src/webfont/webfont.ts
+++ b/packages/assetpack/src/webfont/webfont.ts
@@ -3,7 +3,7 @@ import { fonts } from './fonts.js';
 
 import type { Asset, AssetPipe } from '../core/index.js';
 
-export function webfont(): AssetPipe<any, 'wf'>
+export function webfont(): AssetPipe<any, 'wf', 'family'>
 {
     return {
         folder: false,
@@ -11,6 +11,9 @@ export function webfont(): AssetPipe<any, 'wf'>
         defaultOptions: null,
         tags: {
             wf: 'wf',
+        },
+        dataTags: {
+            family: 'family',
         },
         test(asset: Asset)
         {
@@ -42,6 +45,9 @@ export function webfont(): AssetPipe<any, 'wf'>
             const newAsset = createNewAssetAt(asset, newFileName);
 
             newAsset.buffer = buffer;
+
+            // set the family name to the filename if it doesn't exist
+            asset.manifestData.family = asset.metaData.family ?? path.trimExt(asset.filename);
 
             return [newAsset];
         }

--- a/packages/assetpack/src/webfont/webfont.ts
+++ b/packages/assetpack/src/webfont/webfont.ts
@@ -34,8 +34,7 @@ export function webfont(): AssetPipe<any, 'wf'>
                     buffer = fonts.svg.to.woff2(asset.path);
                     break;
                 default:
-                    throw new Error(`{Assetpack] Unsupported font type: ${ext}`);
-                    break;
+                    throw new Error(`{AssetPack] Unsupported font type: ${ext}`);
             }
 
             const newFileName = asset.filename.replace(/\.(otf|ttf|svg)$/i, '.woff2');

--- a/packages/assetpack/src/webfont/webfont.ts
+++ b/packages/assetpack/src/webfont/webfont.ts
@@ -3,7 +3,7 @@ import { fonts } from './fonts.js';
 
 import type { Asset, AssetPipe } from '../core/index.js';
 
-export function webfont(): AssetPipe<any, 'wf', 'family'>
+export function webfont(): AssetPipe<any, 'wf'>
 {
     return {
         folder: false,
@@ -11,9 +11,6 @@ export function webfont(): AssetPipe<any, 'wf', 'family'>
         defaultOptions: null,
         tags: {
             wf: 'wf',
-        },
-        dataTags: {
-            family: 'family',
         },
         test(asset: Asset)
         {
@@ -47,7 +44,7 @@ export function webfont(): AssetPipe<any, 'wf', 'family'>
             newAsset.buffer = buffer;
 
             // set the family name to the filename if it doesn't exist
-            asset.manifestData.family = asset.metaData.family ?? path.trimExt(asset.filename);
+            asset.metaData.family ??= path.trimExt(asset.filename);
 
             return [newAsset];
         }

--- a/packages/assetpack/test/manifest/Manifest.test.ts
+++ b/packages/assetpack/test/manifest/Manifest.test.ts
@@ -218,6 +218,7 @@ describe('Manifest', () =>
                     alias: ['spine/dragon.atlas'],
                     src: ['spine/dragon@0.5x.atlas', 'spine/dragon.atlas'],
                     data: {
+                        spine: true,
                         tags: {
                             spine: true,
                         },

--- a/packages/assetpack/test/spine/spineAtlasAll.test.ts
+++ b/packages/assetpack/test/spine/spineAtlasAll.test.ts
@@ -168,6 +168,7 @@ describe('Spine Atlas All', () =>
                     // remove the outputDir
                     file = file.replace(`${outputDir}/`, '');
                     const isFileHalfSize = file.includes('@0.5x');
+                    // eslint-disable-next-line no-nested-ternary
                     const isFileFileType = file.includes(isWebp ? '.webp' : isAstc ? '.astc' : '.png');
                     const shouldExist = isHalfSize === isFileHalfSize && isFileType === isFileFileType;
 

--- a/packages/assetpack/test/spine/spineAtlasManifest.test.ts
+++ b/packages/assetpack/test/spine/spineAtlasManifest.test.ts
@@ -78,6 +78,7 @@ describe('Atlas Manifest', () =>
                                 'dragon.atlas'
                             ],
                             data: {
+                                spine: true,
                                 tags: {
                                     spine: true
                                 }
@@ -182,6 +183,7 @@ describe('Atlas Manifest', () =>
                                     'dragon.atlas'
                                 ],
                                 data: {
+                                    spine: true,
                                     tags: {
                                         spine: true
                                     }
@@ -206,6 +208,7 @@ describe('Atlas Manifest', () =>
                                     'nested/dragon.atlas'
                                 ],
                                 data: {
+                                    spine: true,
                                     tags: {
                                         spine: true
                                     }

--- a/packages/assetpack/test/texture-packer/texturePackerAll.test.ts
+++ b/packages/assetpack/test/texture-packer/texturePackerAll.test.ts
@@ -85,6 +85,7 @@ describe('Texture Packer All', () =>
                     // remove the outputDir
                     file = file.replace(`${outputDir}/`, '');
                     const isFileHalfSize = file.includes('@0.5x');
+                    // eslint-disable-next-line no-nested-ternary
                     const isFileFileType = file.includes(isWebp ? '.webp' : isAstc ? '.astc.ktx' : '.png');
                     const shouldExist = isHalfSize === isFileHalfSize && isFileType === isFileFileType;
 

--- a/packages/assetpack/test/texture-packer/texturePackerCompress.test.ts
+++ b/packages/assetpack/test/texture-packer/texturePackerCompress.test.ts
@@ -52,5 +52,5 @@ describe('Texture Packer Compression', () =>
         expect(sheetWebp.meta.image).toEqual(`sprites.webp`);
         expect(sheetAstc.meta.image).toEqual(`sprites.astc.ktx`);
         expect(sheetBasis.meta.image).toEqual(`sprites.basis.ktx2`);
-    });
+    }, { timeout: 20000 });
 });

--- a/packages/assetpack/test/texture-packer/texturePackerManifest.test.ts
+++ b/packages/assetpack/test/texture-packer/texturePackerManifest.test.ts
@@ -110,5 +110,5 @@ describe('Texture Packer Compression', () =>
                 }
             },
         ]);
-    });
+    }, { timeout: 20000 });
 });

--- a/packages/assetpack/test/webfont/Webfont.test.ts
+++ b/packages/assetpack/test/webfont/Webfont.test.ts
@@ -309,36 +309,40 @@ describe('Webfont', () =>
                     alias: ['defaultFolder/ttf.ttf'],
                     src: ['defaultFolder/ttf.woff2'],
                     data: {
+                        family: 'ttf',
                         tags: {
                             wf: true,
-                        }
+                        },
                     }
                 },
                 {
                     alias: ['msdfFolder/ttf.ttf'],
                     src: ['msdfFolder/ttf.fnt'],
                     data: {
+                        family: 'ttf',
                         tags: {
                             msdf: true,
-                        }
+                        },
                     }
                 },
                 {
                     alias: ['sdfFolder/ttf.ttf'],
                     src: ['sdfFolder/ttf.fnt'],
                     data: {
+                        family: 'ttf',
                         tags: {
                             sdf: true,
-                        }
+                        },
                     }
                 },
                 {
                     alias: ['svgFolder/svg.svg'],
                     src: ['svgFolder/svg.woff2'],
                     data: {
+                        family: 'svg',
                         tags: {
                             wf: true,
-                        }
+                        },
                     }
                 },
             ],

--- a/packages/assetpack/test/webfont/Webfont.test.ts
+++ b/packages/assetpack/test/webfont/Webfont.test.ts
@@ -293,7 +293,7 @@ describe('Webfont', () =>
                 msdfFont(),
                 mipmap(),
                 compress(),
-                pixiManifest(),
+                pixiManifest({ legacyMetaDataOutput: false }),
             ]
         });
 

--- a/packages/assetpack/vitest.config.js
+++ b/packages/assetpack/vitest.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
+        testTimeout: 10000,
         poolOptions: {
             threads: {
                 // Due to the cpu-features and vitest threads incompatibility, see:

--- a/packages/docs/docs/guide/pipes/overview.mdx
+++ b/packages/docs/docs/guide/pipes/overview.mdx
@@ -57,5 +57,12 @@ Each plugin has its own set of tags, so be sure to check the documentation for t
 ### Other Tag Examples
 
 - You can also add multiple tags to a single asset, like this `asset{tag1}{tag2}`.
-- Tags can have data appended to them, like this `asset{tag1:myData}`.
-- Tags can have multiple data values, like this `asset{tag1:100,200}`.
+- Tags can have data appended to them, like this `asset{tag1=myData}`.
+- Tags can have multiple data values, like this `asset{tag1=100&200}`.
+
+### Data Tags
+
+Data tags are a special type of tag that a plugin can specify to allow for the value of that tag to be passed to the manifest.
+This can be useful for PixiJS as in the manifest you can specify certain properties for each asset.
+
+For example, the webfont plugin has a `family` tag that can be used to specify the font family name of the font file.

--- a/packages/docs/docs/guide/pipes/webfont.mdx
+++ b/packages/docs/docs/guide/pipes/webfont.mdx
@@ -30,9 +30,10 @@ export default {
 
 ### Tags
 
-| Tag  | Folder/File | Description                                                    |
-| ---- | ----------- | -------------------------------------------------------------- |
-| `wf` | `both`      | If present the file(s) will be converted to a webfont (woff2). |
+| Tag      | Folder/File | Description                                                    |
+| -------- | ----------- | -------------------------------------------------------------- |
+| `wf`     | `both`      | If present the file(s) will be converted to a webfont (woff2). |
+| `family` | `file`      | The font family name.                                          |
 
 ---
 
@@ -80,7 +81,8 @@ export default {
 
 ### Tags
 
-| Tag    | Folder/File | Description                                              |
-| ------ | ----------- | -------------------------------------------------------- |
-| `sdf`  | `both`      | If present the file(s) will be converted to a SDF font.  |
-| `msdf` | `both`      | If present the file(s) will be converted to a MSDF font. |
+| Tag      | Folder/File | Description                                              |
+| -------- | ----------- | -------------------------------------------------------- |
+| `sdf`    | `both`      | If present the file(s) will be converted to a SDF font.  |
+| `msdf`   | `both`      | If present the file(s) will be converted to a MSDF font. |
+| `family` | `file`      | The font family name.                                    |


### PR DESCRIPTION
This PR allows tags that are not defined by assetpack to be added to the manifest data object directly, instead of being under the tags section.

I've added the `legacyMetaData` option to the manifest plugin which will still add these custom tags to the `tags` section in the manifest for backwards compatibility.

This PR also fixes the issue with fonts not working with cache busting it adds the `family` tag and then pixi is able to read this directly