### PR TITLE
fix: Bump gpu-tex-enc to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3777,12 +3777,9 @@
       }
     },
     "node_modules/@gpu-tex-enc/astc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@gpu-tex-enc/astc/-/astc-4.7.0.tgz",
-      "integrity": "sha512-YBeXSYM/WP71hAxLgFxpaF6VEe2dwkS9rjTtKMPRDJEJoja/NIHWrqScwJC600UyxY7kLsjFTek7W6WtYzyi8A==",
-      "dependencies": {
-        "cpu-features": "^0.0.9"
-      },
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@gpu-tex-enc/astc/-/astc-4.7.1.tgz",
+      "integrity": "sha512-ku4RvhQ+qp/k0bp8FbUvJGxfn/nf4FN0tMngPCyDiXbzzSeQip0QausfUt6gILlFGZHtlO+zO7SNkkacDJN3Rw==",
       "bin": {
         "astcenc-darwin-arm64-avx2": "bin/darwin/astcenc",
         "astcenc-darwin-arm64-sse2": "bin/darwin/astcenc",
@@ -3799,15 +3796,15 @@
         "astcenc-win32-x64-avx2": "bin/win32-x64/astcenc-avx2.exe",
         "astcenc-win32-x64-sse2": "bin/win32-x64/astcenc-sse2.exe",
         "astcenc-win32-x64-sse4.1": "bin/win32-x64/astcenc-sse4.1.exe"
+      },
+      "optionalDependencies": {
+        "cpu-features": "^0.0.10"
       }
     },
     "node_modules/@gpu-tex-enc/basis": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@gpu-tex-enc/basis/-/basis-1.16.3.tgz",
-      "integrity": "sha512-u5ooQXTb5UasL8rI2kWz1CMuSARKgvTK2TjQqnOTVWg5gW/HZu0hn+2WkgjkqHKgkxtVIHHJuN2esCu+EmnShQ==",
-      "dependencies": {
-        "cpu-features": "^0.0.9"
-      },
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@gpu-tex-enc/basis/-/basis-1.16.4.tgz",
+      "integrity": "sha512-J3tnW84Frz+BtnTLp7PmpX9LuRenUxreP1upq/UVwaouyy4UWLQaLatjkHaFww35R7dnr2S4zi5YiB1O+GH9+w==",
       "bin": {
         "basisu-darwin-arm64": "bin/darwin-arm64/basisu",
         "basisu-darwin-arm64-sse": "bin/darwin-arm64/basisu",
@@ -3819,6 +3816,9 @@
         "basisu-linux-x64-sse": "bin/linux-x64/basisu-sse",
         "basisu-win32-x64": "bin/win32-x64/basisu.exe",
         "basisu-win32-x64-sse": "bin/win32-x64/basisu-sse.exe"
+      },
+      "optionalDependencies": {
+        "cpu-features": "^0.0.10"
       }
     },
     "node_modules/@gpu-tex-enc/bc": {
@@ -10887,6 +10887,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
       "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -12169,13 +12170,14 @@
       }
     },
     "node_modules/cpu-features": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
-      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "buildcheck": "~0.0.6",
-        "nan": "^2.17.0"
+        "nan": "^2.19.0"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -16225,12 +16227,12 @@
       }
     },
     "node_modules/gpu-tex-enc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/gpu-tex-enc/-/gpu-tex-enc-1.2.4.tgz",
-      "integrity": "sha512-1dRld8Lovtw1xaHH5PEz/SUTiC+1SFS+C71psupWOfgoRknTBdSIdARCP5IwPUlvVdKeRdMK8HKD+u/asOjt5g==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/gpu-tex-enc/-/gpu-tex-enc-1.2.5.tgz",
+      "integrity": "sha512-4kCvhEYMN2OrDiAYDau54rlKrLv/fLUBsp5nUXKi7GoF2Muumy0QJ9j3URXfiM313WGId78+lJeprTFEhWPcVA==",
       "dependencies": {
-        "@gpu-tex-enc/astc": "^4.7.0",
-        "@gpu-tex-enc/basis": "^1.16.3",
+        "@gpu-tex-enc/astc": "^4.7.1",
+        "@gpu-tex-enc/basis": "^1.16.4",
         "@gpu-tex-enc/bc": "^1.0.11",
         "@gpu-tex-enc/etc": "^1.0.3",
         "yargs": "^17.7.2"
@@ -24208,7 +24210,8 @@
     "node_modules/nan": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw=="
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -32159,7 +32162,7 @@
         "fluent-ffmpeg": "^2.1.3",
         "fs-extra": "^11.2.0",
         "glob": "^10.4.1",
-        "gpu-tex-enc": "^1.2.4",
+        "gpu-tex-enc": "^1.2.5",
         "maxrects-packer": "^2.7.3",
         "merge": "^2.1.1",
         "minimatch": "9.0.4",

--- a/packages/assetpack/package.json
+++ b/packages/assetpack/package.json
@@ -69,7 +69,7 @@
     "fluent-ffmpeg": "^2.1.3",
     "fs-extra": "^11.2.0",
     "glob": "^10.4.1",
-    "gpu-tex-enc": "^1.2.4",
+    "gpu-tex-enc": "^1.2.5",
     "maxrects-packer": "^2.7.3",
     "merge": "^2.1.1",
     "minimatch": "9.0.4",


### PR DESCRIPTION
Bump `gpu-tex-enc` to version 1.2.5, where the `cpu-features` library is made optional.