### PR TITLE
add support for json5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "json5": "^2.2.3"
+      },
       "devDependencies": {
         "@pixi/extension-scripts": "^2.4.1",
         "@tsconfig/node20": "^20.1.4",

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "lint": [
       "**/*.{ts,tsx}"
     ]
+  },
+  "dependencies": {
+    "json5": "^2.2.3"
   }
 }

--- a/packages/assetpack/src/json/index.ts
+++ b/packages/assetpack/src/json/index.ts
@@ -1,3 +1,4 @@
+import json5 from 'json5';
 import { checkExt, createNewAssetAt, Logger } from '../core/index.js';
 
 import type { Asset, AssetPipe } from '../core/index.js';
@@ -13,14 +14,18 @@ export function json(): AssetPipe<any, 'nc'>
         },
         test(asset: Asset)
         {
-            return !asset.metaData[this.tags!.nc] && checkExt(asset.path, '.json');
+            return !asset.metaData[this.tags!.nc] && checkExt(asset.path, '.json', '.json5');
         },
         async transform(asset: Asset)
         {
             try
             {
-                const json = JSON.parse(asset.buffer.toString());
-                const compressedJsonAsset = createNewAssetAt(asset, asset.filename);
+                const json = json5.parse(asset.buffer.toString());
+
+                // replace the json5 with json
+                const filename = asset.filename.replace('.json5', '.json');
+
+                const compressedJsonAsset = createNewAssetAt(asset, filename);
 
                 compressedJsonAsset.buffer = Buffer.from(JSON.stringify(json));
 

--- a/packages/assetpack/test/json/Json.test.ts
+++ b/packages/assetpack/test/json/Json.test.ts
@@ -1,3 +1,4 @@
+import { readJSONSync } from 'fs-extra';
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { AssetPack } from '../../src/core/index.js';
@@ -123,5 +124,47 @@ describe('Json', () =>
         const data = readFileSync(`${outputDir}/json/json.json`, 'utf8');
 
         expect(data.replace(/\\/g, '').trim()).toEqual(`{"hello":"world","Im":"not broken"}`);
+    });
+
+    it('should support json5 format', async () =>
+    {
+        const testName = 'json5';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        createFolder(
+            pkg,
+            {
+                name: testName,
+                files: [
+                    {
+                        name: 'json5.json',
+                        content: assetPath('json/json5.json'),
+                    },
+                    {
+                        name: 'other-json-5.json5',
+                        content: assetPath('json/json5.json'),
+                    },
+                ],
+                folders: [],
+            }
+        );
+
+        const assetpack = new AssetPack({
+            entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: false,
+            pipes: [
+                json()
+            ]
+        });
+
+        await assetpack.run();
+
+        const json5Data = readJSONSync(`${outputDir}/json5.json`, 'utf8');
+
+        expect(json5Data).toEqual({ hello: 'world', Im: 'not broken' });
+
+        expect(existsSync(`${outputDir}/other-json-5.json`)).toBe(true);
     });
 });

--- a/packages/assetpack/test/resources/json/json5.json
+++ b/packages/assetpack/test/resources/json/json5.json
@@ -1,0 +1,5 @@
+{
+    // so cool support for comments
+    hello: "world",
+    Im: "not broken"
+}


### PR DESCRIPTION
Adds support for the `.json5` format. Basically allows for json files to have comments and few other quality of life things. See more [here](https://www.npmjs.com/package/json5)

This just upgrades our existing json parser to use the json5 parser instead. Which means json5 files will be transformed to json files. 

You can also add comments to your json files and they will be stripped out.

example of valid json5:

`myJson.json5` 

```js
{
    // so cool support for comments
    hello: "world",
    Im: "not broken"
}
```
woud become:

`myJson.json`

```json
{"hello":"world","Im":"not broken"}
```

tests added 👍 

