### PR TITLE
feat: Added support for nameStyle option in Manifest

### DIFF
--- a/packages/assetpack/src/manifest/pixiManifest.ts
+++ b/packages/assetpack/src/manifest/pixiManifest.ts
@@ -48,8 +48,8 @@ export interface PixiManifestOptions extends PluginOptions
      */
     includeMetaData?: boolean;
     /**
-     * The name style for assets in the manifest file.
-     * When set to relative, assets will use their relative paths as names.
+     * The name style for asset bundles in the manifest file.
+     * When set to relative, asset bundles will use their relative paths as names.
      */
     nameStyle?: 'short' | 'relative';
     /**

--- a/packages/assetpack/test/manifest/Manifest.test.ts
+++ b/packages/assetpack/test/manifest/Manifest.test.ts
@@ -1038,6 +1038,236 @@ describe('Manifest', () =>
         });
     });
 
+    it('should ensure sub-manifests are created correctly with short names', async () =>
+    {
+        const testName = 'manifest-sub-manifest-short';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        createFolder(pkg, {
+            name: testName,
+            files: [],
+            folders: [
+                {
+                    name: 'sound{m}',
+                    files: [
+                        {
+                            name: '1.mp3',
+                            content: assetPath('audio/1.mp3'),
+                        },
+                    ],
+                    folders: [],
+                },
+                {
+                    name: 'sound2{m}',
+                    files: [
+                        {
+                            name: '2.mp3',
+                            content: assetPath('audio/1.mp3'),
+                        },
+                    ],
+                    folders: [],
+                },
+                {
+                    name: 'sound3{m}',
+                    files: [
+                        {
+                            name: '3.mp3',
+                            content: assetPath('audio/1.mp3'),
+                        },
+                    ],
+                    folders: [
+                        {
+                            name: 'sound2{m}',
+                            files: [
+                                {
+                                    name: '2.mp3',
+                                    content: assetPath('audio/1.mp3'),
+                                },
+                            ],
+                            folders: [],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const assetpack = new AssetPack({
+            entry: inputDir,
+            cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: false,
+            pipes: [
+                pixiManifest({
+                    includeMetaData: false,
+                }),
+            ],
+        });
+
+        await assetpack.run();
+
+        expect(fs.readJSONSync(`${outputDir}/manifest.json`)).toEqual({
+            bundles: [
+                {
+                    name: 'default',
+                    assets: [],
+                },
+                {
+                    name: 'sound2',
+                    assets: [
+                        {
+                            alias: ['sound2/2.mp3'],
+                            src: ['sound2/2.mp3'],
+                        },
+                    ],
+                },
+                {
+                    name: 'sound3',
+                    assets: [
+                        {
+                            alias: ['sound3/3.mp3'],
+                            src: ['sound3/3.mp3'],
+                        },
+                    ],
+                },
+                {
+                    name: 'sound3/sound2',
+                    assets: [
+                        {
+                            alias: ['sound3/sound2/2.mp3'],
+                            src: ['sound3/sound2/2.mp3'],
+                        },
+                    ],
+                },
+                {
+                    name: 'sound',
+                    assets: [
+                        {
+                            alias: ['sound/1.mp3'],
+                            src: ['sound/1.mp3'],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('should ensure sub-manifests are created correctly with relative names', async () =>
+    {
+        const testName = 'manifest-sub-manifest-relative';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        createFolder(pkg, {
+            name: testName,
+            files: [],
+            folders: [
+                {
+                    name: 'sound{m}',
+                    files: [
+                        {
+                            name: '1.mp3',
+                            content: assetPath('audio/1.mp3'),
+                        },
+                    ],
+                    folders: [
+                        {
+                            name: 'sound2{m}',
+                            files: [
+                                {
+                                    name: '2.mp3',
+                                    content: assetPath('audio/1.mp3'),
+                                },
+                            ],
+                            folders: [],
+                        },
+                    ],
+                },
+                {
+                    name: 'sound3{m}',
+                    files: [
+                        {
+                            name: '3.mp3',
+                            content: assetPath('audio/1.mp3'),
+                        },
+                    ],
+                    folders: [
+                        {
+                            name: 'sound2{m}',
+                            files: [
+                                {
+                                    name: '2.mp3',
+                                    content: assetPath('audio/1.mp3'),
+                                },
+                            ],
+                            folders: [],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const assetpack = new AssetPack({
+            entry: inputDir,
+            cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: false,
+            pipes: [
+                pixiManifest({
+                    includeMetaData: false,
+                    nameStyle: 'relative',
+                }),
+            ],
+        });
+
+        await assetpack.run();
+
+        expect(fs.readJSONSync(`${outputDir}/manifest.json`)).toEqual({
+            bundles: [
+                {
+                    name: 'default',
+                    assets: [],
+                },
+                {
+                    name: 'sound3',
+                    assets: [
+                        {
+                            alias: ['sound3/3.mp3'],
+                            src: ['sound3/3.mp3'],
+                        },
+                    ],
+                },
+                {
+                    name: 'sound3/sound2',
+                    assets: [
+                        {
+                            alias: ['sound3/sound2/2.mp3'],
+                            src: ['sound3/sound2/2.mp3'],
+                        },
+                    ],
+                },
+                {
+                    name: 'sound',
+                    assets: [
+                        {
+                            alias: ['sound/1.mp3'],
+                            src: ['sound/1.mp3'],
+                        },
+                    ],
+                },
+                {
+                    name: 'sound/sound2',
+                    assets: [
+                        {
+                            alias: ['sound/sound2/2.mp3'],
+                            src: ['sound/sound2/2.mp3'],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
     it('should ignore files with the mIgnore tag', async () =>
     {
         const testName = 'manifest-ignore';

--- a/packages/docs/docs/guide/pipes/manifest.mdx
+++ b/packages/docs/docs/guide/pipes/manifest.mdx
@@ -40,6 +40,7 @@ export default {
       createShortcuts: false,
       trimExtensions: false,
       includeMetaData: true,
+      nameStyle: 'short'
     })
   ],
 };
@@ -47,12 +48,13 @@ export default {
 
 ## API
 
-| Option          | Type      | Description                                                                                    |
-| --------------- | --------- | ---------------------------------------------------------------------------------------------- |
-| output          | `string`  | The path to the manifest file.<br />Defaults to the output folder defined in your config.      |
-| createShortcuts | `boolean` | Whether to create the shortest possible alias for an asset.<br />Defaults to `false`.          |
-| trimExtensions  | `boolean` | Whether to trim the extensions from the asset aliases. <br />Defaults to `false`.              |
-| includeMetaData | `boolean` | Whether to include the tags the asset has used in the manifest file. <br />Defaults to `true`. |
+| Option          | Type              | Description                                                                                    |
+| --------------- | ----------------- | ---------------------------------------------------------------------------------------------- |
+| output          | `string`          | The path to the manifest file.<br />Defaults to the output folder defined in your config.      |
+| createShortcuts | `boolean`         | Whether to create the shortest possible alias for an asset.<br />Defaults to `false`.          |
+| trimExtensions  | `boolean`         | Whether to trim the extensions from the asset aliases. <br />Defaults to `false`.              |
+| includeMetaData | `boolean`         | Whether to include the tags the asset has used in the manifest file. <br />Defaults to `true`. |
+| nameStyle       | `short\|relative` | The name style for the bundle names in the manifest file.<br />Defaults to `short`.            |
 
 ## Tags
 


### PR DESCRIPTION
This PR takes care of bundle name conflicts by adding support of `nameStyle` property.
Unlike v0.x.x which used complex regex to extract relative name from path, this PR traverses asset tree and generates the relative name without much effort.
Fixes/Closes #87 