### PR TITLE
fix: apply mipmap fixed resolution accordingly to fixed and largest resolutions

### DIFF
--- a/packages/assetpack/src/image/mipmap.ts
+++ b/packages/assetpack/src/image/mipmap.ts
@@ -51,30 +51,34 @@ export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, '
                 sharpImage: sharp(asset.buffer),
             };
 
+            const { resolutions, fixedResolution } = options as Required<MipmapOptions>
+                || this.defaultOptions;
+
+            const fixedResolutions = {
+                [fixedResolution]: resolutions[fixedResolution]
+            };
+
+            const largestResolution = Math.max(...Object.values(resolutions));
+
             try
             {
                 if (shouldMipmap)
                 {
-                    const { resolutions, fixedResolution } = options as Required<MipmapOptions>
-                        || this.defaultOptions;
-
-                    const fixedResolutions: {[x: string]: number} = {};
-
-                    fixedResolutions[fixedResolution] = resolutions[fixedResolution];
-
                     const resolutionHash = asset.allMetaData[this.tags!.fix]
                         ? fixedResolutions
                         : resolutions;
 
-                    const largestResolution = Math.max(...Object.values(resolutions));
-
                     image.resolution = largestResolution;
 
-                    processedImages = shouldMipmap ? await mipmapSharp(image, resolutionHash, largestResolution) : [image];
+                    processedImages = await mipmapSharp(image, resolutionHash, largestResolution);
                 }
                 else
                 {
-                    processedImages = [image];
+                    image.resolution = fixedResolutions[fixedResolution];
+
+                    processedImages = image.resolution === 1
+                        ? [image]
+                        : processedImages = await mipmapSharp(image, fixedResolutions, largestResolution);
                 }
             }
             catch (error)

--- a/packages/assetpack/src/image/mipmap.ts
+++ b/packages/assetpack/src/image/mipmap.ts
@@ -66,7 +66,7 @@ export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, '
                         ? fixedResolutions
                         : resolutions;
 
-                    const largestResolution = Math.max(...Object.values(resolutionHash));
+                    const largestResolution = Math.max(...Object.values(resolutions));
 
                     image.resolution = largestResolution;
 

--- a/packages/assetpack/test/image/Mipmap.test.ts
+++ b/packages/assetpack/test/image/Mipmap.test.ts
@@ -77,7 +77,7 @@ describe('Mipmap', () =>
                 name: testName,
                 files: [
                     {
-                        name: 'testPng.png',
+                        name: 'testPng{fix}.png',
                         content: assetPath('image/png-1.png'),
                     },
                 ],
@@ -85,7 +85,7 @@ describe('Mipmap', () =>
             });
 
         const mipmapOpts = {
-            resolutions: { low: 0.5 },
+            resolutions: { low: 0.5, default: 1 },
             fixedResolution: 'low'
         };
 
@@ -147,7 +147,7 @@ describe('Mipmap', () =>
 
     it('should prevent mipmaps on file when tagged with fix', async () =>
     {
-        const testName = 'mip-fixed';
+        const testName = 'mip-fixed-prevent';
         const inputDir = getInputDir(pkg, testName);
         const outputDir = getOutputDir(pkg, testName);
 


### PR DESCRIPTION
Hi

Sorry that I am coming without an issue but I think PR is pretty simple so we can start discussion here.

I need to generate fixed resolution other then 1. After migration to assetpack 1.2 (after 0.8) I found out that `fix` tag will not change asset resolution (size) but only naming.
I mean configs like
```
  resolutions: {
    low: 0.5,
    default: 1,
  },
  fixedResolution: 'low'
```
with `fix` tag on asset will copy asset as is without name or size changing.

I can reach needed result with config mentioned before but without `fix` tag applied but then redundant unchanged asset appear as output for default option. 

You can reproduce it with [this](https://github.com/pixijs/assetpack/blob/f293a154cbef42938f965e5e86505d7181bb78da/packages/assetpack/test/image/Mipmap.test.ts#L70) test by adding `fix` tag [here](https://github.com/pixijs/assetpack/blob/f293a154cbef42938f965e5e86505d7181bb78da/packages/assetpack/test/image/Mipmap.test.ts#L80) and adding `default: 1` option [here](https://github.com/pixijs/assetpack/blob/f293a154cbef42938f965e5e86505d7181bb78da/packages/assetpack/test/image/Mipmap.test.ts#L88)
Note: currently this test is overlapped by [this one](https://github.com/pixijs/assetpack/blob/f293a154cbef42938f965e5e86505d7181bb78da/packages/assetpack/test/image/Mipmap.test.ts#L150). I dont know if it made on purpose but you need rename one of them to reproduce

Thanks =)