### PR TITLE
fix: packed asset never power of two

### DIFF
--- a/packages/assetpack/src/texture-packer/packer/fitTextureToPacker.ts
+++ b/packages/assetpack/src/texture-packer/packer/fitTextureToPacker.ts
@@ -1,6 +1,6 @@
 import type { PackTexturesOptions, PixiPacker } from './packTextures.js';
 
-export function fitTextureToPacker(bin: PixiPacker, { width, height, fixedSize, padding }: PackTexturesOptions)
+export function fitTextureToPacker(bin: PixiPacker, { width, height, fixedSize, padding, powerOfTwo }: PackTexturesOptions)
 {
     if (!fixedSize)
     {
@@ -27,6 +27,21 @@ export function fitTextureToPacker(bin: PixiPacker, { width, height, fixedSize, 
         height += padding ?? 0;
         width += padding ?? 0;
     }
-
+    
+    if (powerOfTwo) 
+    {
+        height = nearestPowerOf2(height);
+        width = nearestPowerOf2(width);
+    }
+    
     return { width, height } as { width: number, height: number};
+}
+
+function nearestPowerOf2(x) {
+    if (x <= 1) return 1;
+    let power = 1;
+    while (power < x) {
+        power <<= 1;
+    }
+    return power;
 }

--- a/packages/assetpack/src/texture-packer/packer/fitTextureToPacker.ts
+++ b/packages/assetpack/src/texture-packer/packer/fitTextureToPacker.ts
@@ -27,21 +27,25 @@ export function fitTextureToPacker(bin: PixiPacker, { width, height, fixedSize, 
         height += padding ?? 0;
         width += padding ?? 0;
 
-        if (powerOfTwo) 
+        if (powerOfTwo)
         {
             height = nearestPowerOf2(height);
             width = nearestPowerOf2(width);
         }
-    }    
+    }
 
     return { width, height } as { width: number, height: number};
 }
 
-function nearestPowerOf2(x: number) {
+function nearestPowerOf2(x: number)
+{
     if (x <= 1) return 1;
     let power = 1;
-    while (power < x) {
+
+    while (power < x)
+    {
         power <<= 1;
     }
+
     return power;
 }

--- a/packages/assetpack/src/texture-packer/packer/fitTextureToPacker.ts
+++ b/packages/assetpack/src/texture-packer/packer/fitTextureToPacker.ts
@@ -26,18 +26,18 @@ export function fitTextureToPacker(bin: PixiPacker, { width, height, fixedSize, 
 
         height += padding ?? 0;
         width += padding ?? 0;
-    }
-    
-    if (powerOfTwo) 
-    {
-        height = nearestPowerOf2(height);
-        width = nearestPowerOf2(width);
-    }
-    
+
+        if (powerOfTwo) 
+        {
+            height = nearestPowerOf2(height);
+            width = nearestPowerOf2(width);
+        }
+    }    
+
     return { width, height } as { width: number, height: number};
 }
 
-function nearestPowerOf2(x) {
+function nearestPowerOf2(x: number) {
     if (x <= 1) return 1;
     let power = 1;
     while (power < x) {

--- a/packages/assetpack/test/texture-packer/texturePacker.test.ts
+++ b/packages/assetpack/test/texture-packer/texturePacker.test.ts
@@ -52,6 +52,48 @@ describe('Texture Packer', () =>
         expect(existsSync(`${outputDir}/sprites`)).toBe(false);
     });
 
+    it('should create a sprite sheet: power of two', async () =>
+    {
+        const testName = 'tp-pot';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        createTPSFolder(testName, pkg);
+
+        const assetpack = new AssetPack({
+            entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: false,
+            pipes: [
+                texturePacker({
+                    texturePacker: {
+                        powerOfTwo: true,
+                    },
+                    resolutionOptions: {
+                        resolutions: { default: 1 },
+                    },
+                })
+            ]
+        });
+
+        await assetpack.run();
+
+        const sheet1 = fs.readJSONSync(`${outputDir}/sprites.json`);
+
+        const expectedSize = {
+            w: 1024,
+            h: 512,
+        };
+
+        expect(sheet1.meta.size).toEqual(expectedSize);
+
+        const sheet2Exists = existsSync(`${outputDir}/sprites-1.json`);
+
+        expect(sheet2Exists).toBe(false);
+
+        expect(existsSync(`${outputDir}/sprites`)).toBe(false);
+    });
+
     it('should adjust the size of the textures outputted based on maximumTextureSize', async () =>
     {
         const testName = 'tp-max-size';


### PR DESCRIPTION
Since setting power of two is never used anywhere, I add logic check and process power of two for texture size.