### PR TITLE
fix: node 22 support

### DIFF
--- a/packages/assetpack/src/cli/index.ts
+++ b/packages/assetpack/src/cli/index.ts
@@ -52,7 +52,9 @@ async function main()
     try
     {
         /* eslint-disable @typescript-eslint/no-var-requires, global-require */
-        config = require(configPath) as AssetPackConfig;
+        const configModule = require(configPath);
+
+        config = (configModule.__esModule ? configModule.default : configModule);
         AssetPack = require('@assetpack/core').AssetPack;
         /* eslint-enable @typescript-eslint/no-var-requires, global-require */
     }


### PR DESCRIPTION
closes #107

Newer versions of node no longer throw `ERR_REQUIRE_ESM` when using `require` on a esm file, we now check to see if `__esModule` is defined instead