### PR TITLE
feat: add stat object that stores transformation information 

### DIFF
--- a/packages/assetpack/src/core/Asset.ts
+++ b/packages/assetpack/src/core/Asset.ts
@@ -6,10 +6,14 @@ import { path } from './utils/path.js';
 
 export interface TransformStats
 {
-    duration: number; // Duration of the transformation process
-    date: number; // The last time the asset was transformed
-    success: boolean; // Whether the transformation was successful
-    error?: string; // Error message if the transformation failed
+    /* The duration of the transformation */
+    duration: number;
+    /* The last time the asset was transformed */
+    date: number;
+    /* Whether the transformation was successful */
+    success: boolean;
+    /* Error message if the transformation failed */
+    error?: string;
 }
 
 export interface AssetOptions

--- a/packages/assetpack/src/core/Asset.ts
+++ b/packages/assetpack/src/core/Asset.ts
@@ -4,6 +4,14 @@ import { extractTagsFromFileName } from './utils/extractTagsFromFileName.js';
 import { getHash } from './utils/getHash.js';
 import { path } from './utils/path.js';
 
+export interface TransformStats
+{
+    duration: number; // Duration of the transformation process
+    date: number; // The last time the asset was transformed
+    success: boolean; // Whether the transformation was successful
+    error?: string; // Error message if the transformation failed
+}
+
 export interface AssetOptions
 {
     path: string;
@@ -37,6 +45,8 @@ export class Asset
     isFolder: boolean;
     path = '';
     skip = false;
+
+    stats?: TransformStats;
 
     private _state: 'deleted' | 'added' | 'modified' | 'normal' = 'added';
     private _buffer?: Buffer | null = null;

--- a/packages/assetpack/src/core/AssetCache.ts
+++ b/packages/assetpack/src/core/AssetCache.ts
@@ -73,13 +73,8 @@ export class AssetCache implements IAssetCache
 
         fs.writeJSONSync(`${AssetCache.location}/${this._cacheName}.json`, schema, { spaces: 4 });
 
-        console.log('wrote cache');
-
+        // assign the schema to the cache data
         this._assetCacheData = schema;
-        for (const i in schema.assets)
-        {
-            console.log(`${i} : `, schema.assets[i].hash);
-        }
     }
 
     private _serializeAsset(asset: Asset, schema: AssetCacheData['assets'], saveHash = false)

--- a/packages/assetpack/src/core/AssetCache.ts
+++ b/packages/assetpack/src/core/AssetCache.ts
@@ -1,14 +1,33 @@
 import fs from 'fs-extra';
 import { path } from './utils/path.js';
 
-import type { Asset } from './Asset.js';
+import type { Asset, TransformStats } from './Asset.js';
 
 export interface AssetCacheOptions
 {
     cacheName?: string;
 }
 
-export class AssetCache
+/**
+ * Interface representing the Asset Cache.
+ * This interface defines the methods required for reading from and writing to the asset cache.
+ */
+export interface IAssetCache
+{
+    /**
+     * Reads the asset cache and returns a record of cached assets.
+     * @returns {Record<string, CachedAsset>} A record containing the cached assets.
+     */
+    read(): Record<string, CachedAsset>;
+
+    /**
+     * Writes an asset to the cache. this is usually the root asset.
+     * @param {Asset} asset - The asset to be written to the cache.
+     */
+    write(asset: Asset): void;
+}
+
+export class AssetCache implements IAssetCache
 {
     public static location = '.assetpack';
     private _assetCacheData: AssetCacheData | undefined;
@@ -18,6 +37,12 @@ export class AssetCache
     {
         this._cacheName = cacheName ?? 'assets';
     }
+
+    exists()
+    {
+        return fs.existsSync(`${AssetCache.location}/${this._cacheName}.json`);
+    }
+
     // save a file to disk
     read()
     {
@@ -31,7 +56,7 @@ export class AssetCache
         }
         catch (e)
         {
-            return null;
+            return {};
         }
     }
 
@@ -47,6 +72,14 @@ export class AssetCache
         fs.ensureDirSync(path.joinSafe(AssetCache.location));
 
         fs.writeJSONSync(`${AssetCache.location}/${this._cacheName}.json`, schema, { spaces: 4 });
+
+        console.log('wrote cache');
+
+        this._assetCacheData = schema;
+        for (const i in schema.assets)
+        {
+            console.log(`${i} : `, schema.assets[i].hash);
+        }
     }
 
     private _serializeAsset(asset: Asset, schema: AssetCacheData['assets'], saveHash = false)
@@ -75,7 +108,8 @@ export class AssetCache
             transformParent: asset.transformParent?.path,
             metaData: { ...asset.metaData },
             inheritedMetaData: { ...asset.inheritedMetaData },
-            transformData: { ...asset.transformData }
+            transformData: { ...asset.transformData },
+            stats: asset.stats ? { ...asset.stats } : undefined
         };
 
         if (!asset.isFolder && saveHash)
@@ -96,6 +130,7 @@ export interface CachedAsset
     inheritedMetaData: Record<string, any>;
     transformData: Record<string, any>;
     transformParent: string | undefined;
+    stats: TransformStats | undefined;
 }
 
 type AssetCacheData = {

--- a/packages/assetpack/src/core/AssetCache.ts
+++ b/packages/assetpack/src/core/AssetCache.ts
@@ -25,6 +25,12 @@ export interface IAssetCache
      * @param {Asset} asset - The asset to be written to the cache.
      */
     write(asset: Asset): void;
+
+    /**
+     * Checks if the asset cache exists.
+     * @returns {boolean} Whether the asset cache exists.
+     */
+    exists(): boolean;
 }
 
 export class AssetCache implements IAssetCache

--- a/packages/assetpack/src/core/AssetPack.ts
+++ b/packages/assetpack/src/core/AssetPack.ts
@@ -153,6 +153,9 @@ export class AssetPack
         return this._assetWatcher.watch();
     }
 
+    /**
+     * Stop the asset pack, this will stop the watcher
+     */
     public stop()
     {
         return this._assetWatcher.stop();

--- a/packages/assetpack/src/core/AssetPack.ts
+++ b/packages/assetpack/src/core/AssetPack.ts
@@ -9,8 +9,7 @@ import { generateCacheName } from './utils/generateCacheName.js';
 import { path } from './utils/path.js';
 import { promiseAllConcurrent } from './utils/promiseAllConcurrent.js';
 
-import type { Asset } from './Asset.js';
-import type { CachedAsset } from './AssetCache.js';
+import type { Asset, TransformStats } from './Asset.js';
 import type { AssetPackConfig } from './config.js';
 import type { AssetPipe } from './pipes/AssetPipe.js';
 import type { AssetSettings } from './pipes/PipeSystem.js';
@@ -47,8 +46,7 @@ export class AssetPack
         const { pipes, cache, cacheLocation } = this.config;
 
         AssetCache.location = cacheLocation!;
-        let assetCacheData: Record<string, CachedAsset> | null = null;
-        let assetCache: AssetCache | null = null;
+        let assetCache: AssetCache | undefined;
 
         // if there is no cache, lets just go ahead and remove the output folder
         // and the cached info folder
@@ -67,9 +65,7 @@ export class AssetPack
 
             // read the cache data, this will be used to restore the asset graph
             // by the AssetWatcher
-            assetCacheData = assetCache.read();
-
-            if (assetCacheData)
+            if (assetCache.exists())
             {
                 Logger.info('[AssetPack] cache found.');
             }
@@ -104,7 +100,7 @@ export class AssetPack
         // so it can be restored even if the process is terminated
         this._assetWatcher = new AssetWatcher({
             entryPath: this._entryPath,
-            assetCacheData,
+            assetCache,
             ignore: this.config.ignore,
             assetSettingsData: this.config.assetSettings as AssetSettings[] || [],
             onUpdate: async (root: Asset) =>
@@ -162,6 +158,11 @@ export class AssetPack
         return this._assetWatcher.stop();
     }
 
+    public get rootAsset()
+    {
+        return this._assetWatcher.root;
+    }
+
     private async _transform(asset: Asset)
     {
         await this._pipeSystem.start(asset);
@@ -177,11 +178,25 @@ export class AssetPack
             {
                 if (asset.skip) return;
 
+                const stats = asset.stats = {
+                    date: Date.now(),
+                    duration: 0,
+                    success: true,
+                } as TransformStats;
+
+                const now = performance.now();
+
                 await this._pipeSystem.transform(asset).catch((e) =>
                 {
+                    stats.success = false;
+                    stats.error = e.message;
+
                     // eslint-disable-next-line max-len
                     Logger.error(`[AssetPack] Transform failed:\ntransform: ${e.name}\nasset:${asset.path}\nerror:${e.message}`);
                 });
+
+                stats.duration = performance.now() - now;
+
                 index++;
 
                 const percent = Math.round((index / assetsToTransform.length) * 100);

--- a/packages/assetpack/src/core/logger/Logger.ts
+++ b/packages/assetpack/src/core/logger/Logger.ts
@@ -60,7 +60,7 @@ class LoggerClass
 
     public report(event: ReporterEvent)
     {
-        // this._reporter.report(event);
+        this._reporter.report(event);
     }
 }
 

--- a/packages/assetpack/src/core/logger/Logger.ts
+++ b/packages/assetpack/src/core/logger/Logger.ts
@@ -60,7 +60,7 @@ class LoggerClass
 
     public report(event: ReporterEvent)
     {
-        this._reporter.report(event);
+        // this._reporter.report(event);
     }
 }
 

--- a/packages/assetpack/src/core/utils/syncAssetsWithCache.ts
+++ b/packages/assetpack/src/core/utils/syncAssetsWithCache.ts
@@ -77,6 +77,7 @@ function syncAssetsFromCache(assetHash: Record<string, Asset>, cachedData: Recor
         else
         {
             asset.state = 'normal';
+            asset.stats = cachedData[i].stats;
         }
     }
 }

--- a/packages/assetpack/test/core/AssetWatcher.test.ts
+++ b/packages/assetpack/test/core/AssetWatcher.test.ts
@@ -29,7 +29,6 @@ describe('AssetWatcher', () =>
 
         const assetWatcher = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: null,
             onUpdate: async (root: Asset) =>
             {
                 expect(root.state).toBe('added');
@@ -69,7 +68,6 @@ describe('AssetWatcher', () =>
 
         const assetWatcher = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: null,
             onUpdate: async (root: Asset) =>
             {
                 expect(root.state).toBe('added');
@@ -90,7 +88,7 @@ describe('AssetWatcher', () =>
 
         const assetWatcherWithCacheData = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: await assetCache.read(),
+            assetCache,
             onUpdate: async (root: Asset) =>
             {
                 expect(root.state).toBe('normal');
@@ -110,7 +108,7 @@ describe('AssetWatcher', () =>
         // and a final time to check that a warm cache is working
         const assetWatcherWithCacheDataWarm = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: await assetCache.read(),
+            assetCache,
             onUpdate: async (root: Asset) =>
             {
                 expect(root.state).toBe('normal');
@@ -187,7 +185,7 @@ describe('AssetWatcher', () =>
 
         const assetWatcher = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: null,
+            assetCache,
             onUpdate,
             onComplete
         });
@@ -196,7 +194,7 @@ describe('AssetWatcher', () =>
 
         const assetWatcherFromCache = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: await assetCache.read(),
+            assetCache,
             onUpdate: async () =>
             {
                 // nothing to do! as it SHOULD be cached :D
@@ -242,7 +240,6 @@ describe('AssetWatcher', () =>
 
         const assetWatcher = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: null,
             onUpdate: async (root: Asset) =>
             {
                 expect(root.children.length).toBe(1);
@@ -291,7 +288,6 @@ describe('AssetWatcher', () =>
 
         const assetWatcher = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: null,
             ignore: '**/*.json',
             onUpdate: async (root: Asset) =>
             {
@@ -353,7 +349,6 @@ describe('AssetWatcher', () =>
 
         const assetWatcher = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: null,
             assetSettingsData: [
                 {
                     files: ['**/*.json'],
@@ -422,7 +417,6 @@ describe('AssetWatcher', () =>
 
         const assetWatcher = new AssetWatcher({
             entryPath: inputDir,
-            assetCacheData: null,
             assetSettingsData: [
                 {
                     files: ['**/*.json'],

--- a/packages/assetpack/test/core/Assetpack.test.ts
+++ b/packages/assetpack/test/core/Assetpack.test.ts
@@ -352,6 +352,100 @@ describe('Core', () =>
         expect(rootAsset.settings).toBeUndefined();
     });
 
+    it('should generate correct stats', async () =>
+    {
+        const testName = 'core-stats';
+        const inputDir = `${getInputDir(pkg, testName)}/`;
+        const outputDir = getOutputDir(pkg, testName);
+
+        fs.removeSync(inputDir);
+
+        createFolder(
+            pkg,
+            {
+                name: testName,
+                files: [{
+                    name: 'json.json',
+                    content: assetPath('json/json.json'),
+                }],
+                folders: [],
+            });
+
+        const assetpack = new AssetPack({
+            entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: false
+        });
+
+        await assetpack.run();
+
+        const stats = assetpack.root.children[0].stats!;
+
+        expect(stats.date).toBeGreaterThan(0);
+        expect(stats.duration).toBeGreaterThan(0);
+        expect(stats.success).toBe(true);
+    });
+
+    it('should generate correct stats when cacheing', async () =>
+    {
+        const testName = 'core-stats-cache';
+        const inputDir = `${getInputDir(pkg, testName)}/`;
+        const outputDir = getOutputDir(pkg, testName);
+
+        fs.removeSync(inputDir);
+
+        createFolder(
+            pkg,
+            {
+                name: testName,
+                files: [{
+                    name: 'json.json',
+                    content: assetPath('json/json.json'),
+                }],
+                folders: [],
+            });
+
+        const testFile = join(inputDir, 'json.json');
+
+        const assetpack = new AssetPack({
+            entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: true
+        });
+
+        fs.writeJSONSync(testFile, { nice: `old value!` });
+
+        await assetpack.run();
+
+        const stats = assetpack.root.children[0].stats!;
+
+        expect(stats.date).toBeGreaterThan(0);
+        expect(stats.duration).toBeGreaterThan(0);
+        expect(stats.success).toBe(true);
+
+        //
+
+        const date = stats.date;
+
+        await assetpack.run();
+
+        // // should maintain the same stats..
+        const stats2 = assetpack.root.children[0].stats!;
+
+        expect(stats2.date).toBe(date);
+        expect(stats2.duration).toBe(stats.duration);
+        expect(stats2.success).toBe(true);
+
+        fs.writeJSONSync(testFile, { nice: 'new value!' });
+
+        await assetpack.run();
+
+        const stats3 = assetpack.root.children[0].stats!;
+
+        expect(stats3.date).toBeGreaterThan(stats.date);
+        expect(stats3.success).toBe(true);
+    });
+
     it('should not copy to output if transformed', () =>
     {
         //

--- a/packages/assetpack/test/core/Assetpack.test.ts
+++ b/packages/assetpack/test/core/Assetpack.test.ts
@@ -379,7 +379,7 @@ describe('Core', () =>
 
         await assetpack.run();
 
-        const stats = assetpack.root.children[0].stats!;
+        const stats = assetpack.rootAsset.children[0].stats!;
 
         expect(stats.date).toBeGreaterThan(0);
         expect(stats.duration).toBeGreaterThan(0);

--- a/packages/assetpack/test/core/Assetpack.test.ts
+++ b/packages/assetpack/test/core/Assetpack.test.ts
@@ -417,7 +417,7 @@ describe('Core', () =>
 
         await assetpack.run();
 
-        const stats = assetpack.root.children[0].stats!;
+        const stats = assetpack.rootAsset.children[0].stats!;
 
         expect(stats.date).toBeGreaterThan(0);
         expect(stats.duration).toBeGreaterThan(0);
@@ -430,7 +430,7 @@ describe('Core', () =>
         await assetpack.run();
 
         // // should maintain the same stats..
-        const stats2 = assetpack.root.children[0].stats!;
+        const stats2 = assetpack.rootAsset.children[0].stats!;
 
         expect(stats2.date).toBe(date);
         expect(stats2.duration).toBe(stats.duration);
@@ -440,10 +440,25 @@ describe('Core', () =>
 
         await assetpack.run();
 
-        const stats3 = assetpack.root.children[0].stats!;
+        const stats3 = assetpack.rootAsset.children[0].stats!;
 
         expect(stats3.date).toBeGreaterThan(stats.date);
         expect(stats3.success).toBe(true);
+    });
+
+    it('should return the root asset', () =>
+    {
+        const testName = 'root-asset';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        const assetpack = new AssetPack({
+            entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: false
+        });
+
+        expect(assetpack.rootAsset).toBeDefined();
     });
 
     it('should not copy to output if transformed', () =>


### PR DESCRIPTION
Added some stats and a few other bits!

1. add stats object to assets
    - All assets not have a little stat object that stores transformation information. Currently this is transform time, transform date, success and error (if success is false).

2. expose root asset
    - Added a `rootAsset` to `AssetPack` so devs who are feeling adventurous can gain access to the underlying assets

3. tweak how we use the cache
    - Whilst writing the test, i realised that when calling `run` on the same assetpack instance multiple times and in between runs, changing the assets in the input folder then things get broken! 
    - The main reason for this was that the cache was written correctly between runs, but only read on the first run. I have adjusted the API so that now `AssetWatcher` now expects an `AssetCache` (with read and write functions) to be passed to it. Seemed to do the trick!

As a follow up I would like to create a `generate stats` function that makes a little report or data dump for users, but that can come later - this is good as a foundational PR! 