### PR TITLE
fix: deleting asset causing crash when watching assets

### DIFF
--- a/packages/assetpack/src/core/Asset.ts
+++ b/packages/assetpack/src/core/Asset.ts
@@ -137,7 +137,12 @@ export class Asset
             Logger.warn('[AssetPack] folders should not have hashes. Contact the developer of the AssetPack');
         }
 
-        this._hash ??= getHash(this.buffer);
+        try
+        {
+            this._hash ??= getHash(this.buffer);
+        }
+        catch (error)
+        { /* empty */ }
 
         return this._hash;
     }

--- a/packages/assetpack/src/spine/spineAtlasCacheBuster.ts
+++ b/packages/assetpack/src/spine/spineAtlasCacheBuster.ts
@@ -52,7 +52,7 @@ export function spineAtlasCacheBuster(): AssetPipe
                 // as we do this, the hash of the atlas file will change, so we need to update the path
                 // and also remove the original file.
 
-                const originalHash = atlasAsset.hash;
+                const originalHash = atlasAsset.hash!;
                 const originalPath = atlasAsset.path;
 
                 const atlasView = new AtlasView(atlasAsset.buffer);
@@ -70,7 +70,7 @@ export function spineAtlasCacheBuster(): AssetPipe
 
                 atlasAsset.buffer = atlasView.buffer;
 
-                atlasAsset.path = atlasAsset.path.replace(originalHash, atlasAsset.hash);
+                atlasAsset.path = atlasAsset.path.replace(originalHash, atlasAsset.hash!);
 
                 fs.removeSync(originalPath);
 

--- a/packages/assetpack/src/texture-packer/texturePackerCacheBuster.ts
+++ b/packages/assetpack/src/texture-packer/texturePackerCacheBuster.ts
@@ -52,7 +52,7 @@ export function texturePackerCacheBuster(): AssetPipe<any, 'tps'>
                 // as we do this, the hash of the atlas file will change, so we need to update the path
                 // and also remove the original file.
                 const jsonAsset = jsonAssets[i];
-                const originalHash = jsonAsset.hash;
+                const originalHash = jsonAsset.hash!;
                 const originalPath = jsonAsset.path;
 
                 const json = JSON.parse(jsonAsset.buffer.toString());
@@ -79,7 +79,7 @@ export function texturePackerCacheBuster(): AssetPipe<any, 'tps'>
                 }
 
                 jsonAsset.buffer = Buffer.from(JSON.stringify(json));
-                jsonAsset.path = jsonAsset.path.replace(originalHash, jsonAsset.hash);
+                jsonAsset.path = jsonAsset.path.replace(originalHash, jsonAsset.hash!);
                 fs.removeSync(originalPath);
 
                 // rewrite..


### PR DESCRIPTION
When watching assets, occasianally one is deleted and we then try to read its hash the item does not exist and an error is thrown.

This PR adds a try catch around this issue. This won't cause any further issues as the asset without the file will have been flagged for deletion anyways.