### PR TITLE
feat: add onComplete to watch

### DIFF
--- a/packages/assetpack/src/core/AssetPack.ts
+++ b/packages/assetpack/src/core/AssetPack.ts
@@ -34,6 +34,18 @@ export class AssetPack
     private _entryPath = '';
     private _outputPath = '';
 
+    /**
+     * Holds onto the optional onComplete callback passed in by the watch method
+     * will be called after each time asset pack has finished transforming the assets
+     */
+    private _onWatchTransformComplete: ((root: Asset) => void) | undefined;
+
+    /**
+     * Holds a promise resolve function that will be called after the first time
+     * asset pack has finished transforming the assets when the watch method is called
+     */
+    private _onWatchInitialTransformComplete: ((value: unknown) => void) | undefined;
+
     constructor(config: AssetPackConfig = {})
     {
         this.config = merge.recursive(true, this._defaultConfig, config);
@@ -136,6 +148,18 @@ export class AssetPack
 
                     Logger.info('cache updated.');
                 }
+
+                this._onWatchTransformComplete?.(root);
+
+                // if the watch method was called, we need to resolve the promise
+                // that was created when the watch method was called
+                if (this._onWatchInitialTransformComplete)
+                {
+                    this._onWatchInitialTransformComplete(root);
+
+                    // clear the promise resolve function, so it only gets resolved once
+                    this._onWatchInitialTransformComplete = undefined;
+                }
             }
         });
     }
@@ -151,10 +175,22 @@ export class AssetPack
     /**
      * Watch the asset pack, this will watch the file system for changes and transform the assets.
      * you can enable this when in development mode
+     *
+     * @param onComplete - optional callback that will be called after each time asset pack has finished transforming the assets
+     * @returns a promise that will resolve when the first time asset pack has finished transforming the assets
      */
-    public watch()
+    public watch(onComplete: (root: Asset) => void)
     {
-        return this._assetWatcher.watch();
+        this._onWatchTransformComplete = onComplete;
+
+        const onCompletePromise = new Promise((resolve) =>
+        {
+            this._onWatchInitialTransformComplete = resolve;
+        });
+
+        this._assetWatcher.watch();
+
+        return onCompletePromise;
     }
 
     public stop()

--- a/packages/assetpack/src/core/AssetPack.ts
+++ b/packages/assetpack/src/core/AssetPack.ts
@@ -179,7 +179,7 @@ export class AssetPack
      * @param onComplete - optional callback that will be called after each time asset pack has finished transforming the assets
      * @returns a promise that will resolve when the first time asset pack has finished transforming the assets
      */
-    public watch(onComplete: (root: Asset) => void)
+    public watch(onComplete?: (root: Asset) => void)
     {
         this._onWatchTransformComplete = onComplete;
 

--- a/packages/assetpack/test/core/Assetpack.test.ts
+++ b/packages/assetpack/test/core/Assetpack.test.ts
@@ -352,7 +352,7 @@ describe('Core', () =>
         expect(rootAsset.settings).toBeUndefined();
     });
 
-    it.only('should call onComplete when the asset pack run is complete when watching', async () =>
+    it('should call onComplete when the asset pack run is complete when watching', async () =>
     {
         const testName = 'watch-onComplete';
         const inputDir = `${getInputDir(pkg, testName)}/`;

--- a/packages/assetpack/test/core/Assetpack.test.ts
+++ b/packages/assetpack/test/core/Assetpack.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { existsSync } from 'node:fs';
 import { join } from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { cacheBuster } from '../../src/cache-buster/cacheBuster.js';
 import { AssetPack } from '../../src/core/AssetPack.js';
 import { getHash } from '../../src/core/index.js';
@@ -350,6 +350,51 @@ describe('Core', () =>
         });
 
         expect(rootAsset.settings).toBeUndefined();
+    });
+
+    it.only('should call onComplete when the asset pack run is complete when watching', async () =>
+    {
+        const testName = 'watch-onComplete';
+        const inputDir = `${getInputDir(pkg, testName)}/`;
+        const outputDir = getOutputDir(pkg, testName);
+
+        fs.removeSync(inputDir);
+
+        createFolder(
+            pkg,
+            {
+                name: testName,
+                files: [{
+                    name: 'json.json',
+                    content: assetPath('json/json.json'),
+                }],
+                folders: [],
+            });
+
+        const testFile = join(inputDir, 'json.json');
+
+        const assetpack = new AssetPack({
+            entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: true
+        });
+
+        const onComplete = vi.fn();
+
+        await assetpack.watch(onComplete);
+
+        expect(onComplete).toHaveBeenCalledTimes(1);
+
+        fs.writeJSONSync(testFile, { nice: `old value!` });
+
+        await new Promise((resolve) =>
+        {
+            setTimeout(resolve, 1500);
+        });
+
+        expect(onComplete).toHaveBeenCalledTimes(2);
+
+        assetpack.stop();
     });
 
     it('should not copy to output if transformed', () =>


### PR DESCRIPTION
- adds an onComplete callback option to watch. This is called each time assetpack has finished updating assets
- fix watch promise resolve to happen at the right time
- add test