### PR TITLE
fix: align texture naming with PixiJS

### DIFF
--- a/packages/assetpack/src/spine/spineAtlasCompress.ts
+++ b/packages/assetpack/src/spine/spineAtlasCompress.ts
@@ -38,7 +38,7 @@ export function spineAtlasCompress(_options?: SpineAtlasCompressOptions): AssetP
             if (options.png) formats.push(['png', '.png']);
             if (options.webp) formats.push(['webp', '.webp']);
             if (options.astc) formats.push(['astc', '.astc.ktx']);
-            if (options.bc7) formats.push(['bc7', '.bc7.dds']);
+            if (options.bc7) formats.push(['bptc', '.bptc.dds']);
             if (options.basis) formats.push(['basis', '.basis.ktx2']);
             if (options.etc) formats.push(['etc', '.etc.ktx']);
 

--- a/packages/assetpack/src/texture-packer/texturePackerCompress.ts
+++ b/packages/assetpack/src/texture-packer/texturePackerCompress.ts
@@ -43,7 +43,7 @@ export function texturePackerCompress(
             if (options.png) formats.push(['png', '.png']);
             if (options.webp) formats.push(['webp', '.webp']);
             if (options.astc) formats.push(['astc', '.astc.ktx']);
-            if (options.bc7) formats.push(['bc7', '.bc7.dds']);
+            if (options.bc7) formats.push(['bptc', '.bptc.dds']);
             if (options.basis) formats.push(['basis', '.basis.ktx2']);
             if (options.etc) formats.push(['etc', '.etc.ktx']);
 


### PR DESCRIPTION
PixiJS expect `bptc` suffix and not `bc7` 