### PR TITLE
feat: Add sharp resize options to mipmap

### DIFF
--- a/packages/assetpack/src/image/mipmap.ts
+++ b/packages/assetpack/src/image/mipmap.ts
@@ -7,7 +7,8 @@ import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
 import type { CompressImageData } from './compress.js';
 import type { SharpResizeOptions } from './utils/mipmapSharp.js';
 
-export interface MipmapOptions extends PluginOptions {
+export interface MipmapOptions extends PluginOptions
+{
     /** A template for denoting the resolution of the images. */
     template?: string;
     /** An object containing the resolutions that the images will be resized to. */

--- a/packages/assetpack/src/image/mipmap.ts
+++ b/packages/assetpack/src/image/mipmap.ts
@@ -5,21 +5,24 @@ import { resolveOptions } from './utils/resolveOptions.js';
 
 import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
 import type { CompressImageData } from './compress.js';
+import type { SharpResizeOptions } from './utils/mipmapSharp.js';
 
-export interface MipmapOptions extends PluginOptions
-{
+export interface MipmapOptions extends PluginOptions {
     /** A template for denoting the resolution of the images. */
     template?: string;
     /** An object containing the resolutions that the images will be resized to. */
     resolutions?: {[x: string]: number};
     /** A resolution used if the fixed tag is applied. Resolution must match one found in resolutions. */
     fixedResolution?: string;
+    /** Options to pass to sharp when resizing images. */
+    sharpResizeOptions?: SharpResizeOptions;
 }
 
 const defaultMipmapOptions: Required<MipmapOptions> = {
     template: '@%%x',
     resolutions: { default: 1, low: 0.5 },
     fixedResolution: 'default',
+    sharpResizeOptions: {},
 };
 
 export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, 'fix' | 'nomip'>
@@ -71,7 +74,7 @@ export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, '
 
                     image.resolution = largestResolution;
 
-                    processedImages = await mipmapSharp(image, resolutionHash, largestResolution);
+                    processedImages = await mipmapSharp(image, resolutionHash, largestResolution, options.sharpResizeOptions);
                 }
                 else
                 {
@@ -79,7 +82,7 @@ export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, '
 
                     processedImages = image.resolution === 1
                         ? [image]
-                        : processedImages = await mipmapSharp(image, fixedResolutions, largestResolution);
+                        : processedImages = await mipmapSharp(image, fixedResolutions, largestResolution, options.sharpResizeOptions);
                 }
             }
             catch (error)

--- a/packages/assetpack/src/image/utils/mipmapSharp.ts
+++ b/packages/assetpack/src/image/utils/mipmapSharp.ts
@@ -1,12 +1,14 @@
+import type { ResizeOptions } from 'sharp';
 import type { CompressImageData } from '../compress.js';
+
+export type SharpResizeOptions = Omit<ResizeOptions, 'width' | 'height'>;
 
 export async function mipmapSharp(
     image: CompressImageData,
     resolutionHash: {[x: string]: number},
-    largestResolution: number
-
-): Promise<CompressImageData[]>
-{
+    largestResolution: number,
+    sharpResizeOptions: SharpResizeOptions,
+): Promise<CompressImageData[]> {
     const sharpImage = image.sharpImage;
 
     const metadata = await sharpImage.metadata();
@@ -33,8 +35,9 @@ export async function mipmapSharp(
                 resolution: resolutionHash[i],
                 sharpImage: sharpImage.clone().resize({
                     width: Math.round(width * scale),
-                    height: Math.round(height * scale)
-                })
+                    height: Math.round(height * scale),
+                    ...sharpResizeOptions,
+                }),
             });
         }
     }

--- a/packages/assetpack/src/image/utils/mipmapSharp.ts
+++ b/packages/assetpack/src/image/utils/mipmapSharp.ts
@@ -8,7 +8,8 @@ export async function mipmapSharp(
     resolutionHash: {[x: string]: number},
     largestResolution: number,
     sharpResizeOptions: SharpResizeOptions,
-): Promise<CompressImageData[]> {
+): Promise<CompressImageData[]>
+{
     const sharpImage = image.sharpImage;
 
     const metadata = await sharpImage.metadata();


### PR DESCRIPTION
This pull request introduces enhancements to the image mipmapping process by adding support for custom Sharp resize options. The most important changes include updates to the `MipmapOptions` interface and modifications to the `mipmapSharp` function to accept and apply these custom options.

Enhancements to mipmapping process:

* [`packages/assetpack/src/image/mipmap.ts`](diffhunk://#diff-dc43f82656b9d50d29d5df418f34bffe28aead3673cc67f7ee7b1d69199f88e7R8-R25): Added `sharpResizeOptions` to the `MipmapOptions` interface and updated the `defaultMipmapOptions` to include an empty object for `sharpResizeOptions`. Modified the `mipmap` function to pass `sharpResizeOptions` to the `mipmapSharp` function. [[1]](diffhunk://#diff-dc43f82656b9d50d29d5df418f34bffe28aead3673cc67f7ee7b1d69199f88e7R8-R25) [[2]](diffhunk://#diff-dc43f82656b9d50d29d5df418f34bffe28aead3673cc67f7ee7b1d69199f88e7L74-R85)
* [`packages/assetpack/src/image/utils/mipmapSharp.ts`](diffhunk://#diff-ab3b468b5c50fb7c7ebf4c9fee45d3c1c52792b6202b30809ce70532fa9b2a2cR1-R11): Introduced the `SharpResizeOptions` type, which omits `width` and `height` from `ResizeOptions`. Updated the `mipmapSharp` function to accept `sharpResizeOptions` and apply them during the image resizing process. [[1]](diffhunk://#diff-ab3b468b5c50fb7c7ebf4c9fee45d3c1c52792b6202b30809ce70532fa9b2a2cR1-R11) [[2]](diffhunk://#diff-ab3b468b5c50fb7c7ebf4c9fee45d3c1c52792b6202b30809ce70532fa9b2a2cL36-R40)