### PR TITLE
Metadata tags

### DIFF
--- a/packages/assetpack/src/core/pipes/AssetPipe.ts
+++ b/packages/assetpack/src/core/pipes/AssetPipe.ts
@@ -1,3 +1,14 @@
+import type { CompressTags } from 'src/image/compress.js';
+import type { MipmapTags } from 'src/image/mipmap.js';
+import type { JsonTags } from 'src/json/index.js';
+import type { PixiManifestTags } from 'src/manifest/pixiManifest.js';
+import type { SpineAtlasCompressTags } from 'src/spine/spineAtlasCompress.js';
+import type { SpineAtlasMipmapTags } from 'src/spine/spineAtlasMipmap.js';
+import type { TexturePackerTags } from 'src/texture-packer/texturePacker.js';
+import type { TexturePackerCacheBusterTags } from 'src/texture-packer/texturePackerCacheBuster.js';
+import type { TexturePackerCompressTags } from 'src/texture-packer/texturePackerCompress.js';
+import type { SigntedFontTags } from 'src/webfont/sdf.js';
+import type { WebfontTags } from 'src/webfont/webfont.js';
 import type { Asset } from '../Asset.js';
 import type { PipeSystem } from './PipeSystem.js';
 
@@ -17,7 +28,21 @@ export type DeepRequired<T> = T extends Primitive
     };
 export interface PluginOptions {}
 
-export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = string, INTERNAL_TAGS extends string = string>
+export type Tags =
+    | CompressTags
+    | MipmapTags
+    | JsonTags
+    | PixiManifestTags
+    | SpineAtlasCompressTags
+    | SpineAtlasMipmapTags
+    | TexturePackerTags
+    | TexturePackerCacheBusterTags
+    | TexturePackerCompressTags
+    | WebfontTags
+    | SigntedFontTags
+    | string & NonNullable<unknown>;
+
+export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends Tags = string, INTERNAL_TAGS extends Tags = string>
 {
     /** Whether the process runs on a folder */
     folder?: boolean;

--- a/packages/assetpack/src/core/pipes/PipeSystem.ts
+++ b/packages/assetpack/src/core/pipes/PipeSystem.ts
@@ -3,9 +3,7 @@ import { mergePipeOptions } from './mergePipeOptions.js';
 import { multiPipe } from './multiPipe.js';
 
 import type { Asset } from '../Asset.js';
-import type { AssetPipe } from './AssetPipe.js';
-
-export type Tags = 'tps' | 'fix' | 'jpg' | 'nomip' | 'm' | 'mIgnore' | 'copy' | 'nc';
+import type { AssetPipe, Tags } from './AssetPipe.js';
 
 export interface PipeSystemOptions
 {

--- a/packages/assetpack/src/core/pipes/PipeSystem.ts
+++ b/packages/assetpack/src/core/pipes/PipeSystem.ts
@@ -5,6 +5,8 @@ import { multiPipe } from './multiPipe.js';
 import type { Asset } from '../Asset.js';
 import type { AssetPipe } from './AssetPipe.js';
 
+export type Tags = 'tps' | 'fix' | 'jpg' | 'nomip' | 'm' | 'mIgnore' | 'copy' | 'nc';
+
 export interface PipeSystemOptions
 {
     pipes: (AssetPipe | AssetPipe[])[];
@@ -16,7 +18,7 @@ export interface AssetSettings
 {
     files: string[],
     settings?: Record<string, any>,
-    metaData?: Record<string, any>
+    metaData?: Record<Tags, boolean> | Record<string, any>,
 }
 
 export class PipeSystem

--- a/packages/assetpack/src/image/compress.ts
+++ b/packages/assetpack/src/image/compress.ts
@@ -43,7 +43,9 @@ export interface CompressImageDataResult
     buffer: Buffer;
 }
 
-export function compress(options: CompressOptions = {}): AssetPipe<CompressOptions, 'nc'>
+export type CompressTags = 'nc';
+
+export function compress(options: CompressOptions = {}): AssetPipe<CompressOptions, CompressTags>
 {
     const compress = resolveOptions<CompressOptions>(options, {
         png: true,

--- a/packages/assetpack/src/image/mipmap.ts
+++ b/packages/assetpack/src/image/mipmap.ts
@@ -16,13 +16,15 @@ export interface MipmapOptions extends PluginOptions
     fixedResolution?: string;
 }
 
+export type MipmapTags = 'fix' | 'nomip';
+
 const defaultMipmapOptions: Required<MipmapOptions> = {
     template: '@%%x',
     resolutions: { default: 1, low: 0.5 },
     fixedResolution: 'default',
 };
 
-export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, 'fix' | 'nomip'>
+export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, MipmapTags>
 {
     const mipmap = resolveOptions(_options, defaultMipmapOptions);
 

--- a/packages/assetpack/src/json/index.ts
+++ b/packages/assetpack/src/json/index.ts
@@ -3,7 +3,9 @@ import { BuildReporter, checkExt, createNewAssetAt } from '../core/index.js';
 
 import type { Asset, AssetPipe } from '../core/index.js';
 
-export function json(): AssetPipe<any, 'nc'>
+export type JsonTags = 'nc';
+
+export function json(): AssetPipe<any, JsonTags>
 {
     return {
         name: 'json',

--- a/packages/assetpack/src/manifest/pixiManifest.ts
+++ b/packages/assetpack/src/manifest/pixiManifest.ts
@@ -81,7 +81,9 @@ export interface PixiManifestOptions extends PluginOptions
     legacyMetaDataOutput?: boolean;
 }
 
-export function pixiManifest(_options: PixiManifestOptions = {}): AssetPipe<PixiManifestOptions, 'manifest' | 'mIgnore'>
+export type PixiManifestTags = 'manifest' | 'mIgnore';
+
+export function pixiManifest(_options: PixiManifestOptions = {}): AssetPipe<PixiManifestOptions, PixiManifestTags>
 {
     return {
         name: 'pixi-manifest',

--- a/packages/assetpack/src/spine/spineAtlasCompress.ts
+++ b/packages/assetpack/src/spine/spineAtlasCompress.ts
@@ -6,7 +6,9 @@ import type { CompressOptions } from '../image/index.js';
 
 export type SpineAtlasCompressOptions = Omit<CompressOptions, 'jpg'>;
 
-export function spineAtlasCompress(_options?: SpineAtlasCompressOptions): AssetPipe<SpineAtlasCompressOptions, 'nc'>
+export type SpineAtlasCompressTags = 'nc';
+
+export function spineAtlasCompress(_options?: SpineAtlasCompressOptions): AssetPipe<SpineAtlasCompressOptions, SpineAtlasCompressTags>
 {
     return {
         name: 'spine-atlas-compress',

--- a/packages/assetpack/src/spine/spineAtlasMipmap.ts
+++ b/packages/assetpack/src/spine/spineAtlasMipmap.ts
@@ -5,7 +5,9 @@ import type { MipmapOptions } from '../image/index.js';
 
 export type SpineOptions = PluginOptions & MipmapOptions;
 
-export function spineAtlasMipmap(_options?: SpineOptions): AssetPipe<SpineOptions, 'fix' | 'nomip'>
+export type SpineAtlasMipmapTags = 'fix' | 'nomip';
+
+export function spineAtlasMipmap(_options?: SpineOptions): AssetPipe<SpineOptions, SpineAtlasMipmapTags>
 {
     return {
         folder: false,

--- a/packages/assetpack/src/texture-packer/texturePacker.ts
+++ b/packages/assetpack/src/texture-packer/texturePacker.ts
@@ -6,6 +6,8 @@ import { packTextures } from './packer/packTextures.js';
 import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
 import type { PackTexturesOptions, TexturePackerFormat } from './packer/packTextures.js';
 
+export type TexturePackerTags = 'tps' | 'fix' | 'jpg' | 'nomip';
+
 export interface TexturePackerOptions extends PluginOptions
 {
     texturePacker?: Partial<PackTexturesOptions>;
@@ -49,7 +51,7 @@ function checkForTexturePackerShortcutClashes(
     }
 }
 
-export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<TexturePackerOptions, 'tps' | 'fix' | 'jpg' | 'nomip'>
+export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<TexturePackerOptions, TexturePackerTags>
 {
     let shortcutClash: Record<string, boolean> = {};
 

--- a/packages/assetpack/src/texture-packer/texturePackerCacheBuster.ts
+++ b/packages/assetpack/src/texture-packer/texturePackerCacheBuster.ts
@@ -3,6 +3,8 @@ import { checkExt, findAssets } from '../core/index.js';
 
 import type { Asset, AssetPipe } from '../core/index.js';
 
+export type TexturePackerCacheBusterTags = 'tps';
+
 /**
  * This should be used after the cache buster plugin in the pipes.
  * As it relies on the cache buster plugin to have already cache busted all files.
@@ -16,7 +18,7 @@ import type { Asset, AssetPipe } from '../core/index.js';
  *
  * @returns
  */
-export function texturePackerCacheBuster(): AssetPipe<any, 'tps'>
+export function texturePackerCacheBuster(): AssetPipe<any, TexturePackerCacheBusterTags>
 {
     const textureJsonFilesToFix: Asset[] = [];
 

--- a/packages/assetpack/src/texture-packer/texturePackerCompress.ts
+++ b/packages/assetpack/src/texture-packer/texturePackerCompress.ts
@@ -5,9 +5,11 @@ import type { CompressOptions } from '../image/compress.js';
 
 export type TexturePackerCompressOptions = Omit<CompressOptions, 'jpg'>;
 
+export type TexturePackerCompressTags = 'tps' | 'nc';
+
 export function texturePackerCompress(
     _options?: TexturePackerCompressOptions,
-): AssetPipe<TexturePackerCompressOptions, 'tps' | 'nc'>
+): AssetPipe<TexturePackerCompressOptions, TexturePackerCompressTags>
 {
     return {
         name: 'texture-packer-compress',

--- a/packages/assetpack/src/webfont/sdf.ts
+++ b/packages/assetpack/src/webfont/sdf.ts
@@ -12,9 +12,11 @@ export interface SDFFontOptions extends PluginOptions
     font?: Omit<BitmapFontOptions, 'outputType' | 'fieldType'>;
 }
 
+export type SigntedFontTags = 'font' | 'nc' | 'nomip';
+
 function signedFont(
     defaultOptions: SDFFontOptions
-): AssetPipe<SDFFontOptions, 'font' | 'nc' | 'nomip'>
+): AssetPipe<SDFFontOptions, SigntedFontTags>
 {
     return {
         folder: false,

--- a/packages/assetpack/src/webfont/webfont.ts
+++ b/packages/assetpack/src/webfont/webfont.ts
@@ -3,7 +3,9 @@ import { fonts } from './fonts.js';
 
 import type { Asset, AssetPipe } from '../core/index.js';
 
-export function webfont(): AssetPipe<any, 'wf'>
+export type WebfontTags = 'wf';
+
+export function webfont(): AssetPipe<any, WebfontTags>
 {
     return {
         folder: false,

--- a/packages/docs/docs/guide/pipes/overview.mdx
+++ b/packages/docs/docs/guide/pipes/overview.mdx
@@ -47,8 +47,6 @@ Each plugin has its own set of tags, so be sure to check the documentation for t
     />
 </div>
 
-
-
 ### Built-in Tags
 
 - `{copy}`: The tags forces an asset to be copied to the output directory, without any processing.
@@ -66,3 +64,22 @@ Data tags are a special type of tag that a plugin can specify to allow for the v
 This can be useful for PixiJS as in the manifest you can specify certain properties for each asset.
 
 For example, the webfont plugin has a `family` tag that can be used to specify the font family name of the font file.
+
+### Defining Tags in Config
+
+In addition to adding tags directly to file or folder names, you can also define them using the metaData field in your configuration. This is especially useful when you want to apply tags without modifying filenames.
+
+```ts
+const appConfig: AssetPackConfig = {
+  entry: './assets',
+
+  assetSettings: [
+    {
+      files: ['**/images'],
+      metaData: {
+        tps: true,
+        // other tags can be added here
+      }
+    }
+  ],
+};


### PR DESCRIPTION
Separated tags by specific type for each pipe – This enhances clarity and modularity when working with different pipelines.
Added an example for defining tags via metaData in the config – This provides a clearer reference for configuring tags.