### PR TITLE
feat: adds sharp processing options

### DIFF
--- a/packages/assetpack/src/image/index.ts
+++ b/packages/assetpack/src/image/index.ts
@@ -1,2 +1,3 @@
 export * from './compress.js';
 export * from './mipmap.js';
+export * from './types.js';

--- a/packages/assetpack/src/image/mipmap.ts
+++ b/packages/assetpack/src/image/mipmap.ts
@@ -5,6 +5,7 @@ import { resolveOptions } from './utils/resolveOptions.js';
 
 import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
 import type { CompressImageData } from './compress.js';
+import type { SharpProcessingOptions } from './types.js';
 
 export interface MipmapOptions extends PluginOptions
 {
@@ -14,12 +15,15 @@ export interface MipmapOptions extends PluginOptions
     resolutions?: {[x: string]: number};
     /** A resolution used if the fixed tag is applied. Resolution must match one found in resolutions. */
     fixedResolution?: string;
+    /** Options to pass to sharp for processing the images. */
+    sharpOptions?: SharpProcessingOptions;
 }
 
 const defaultMipmapOptions: Required<MipmapOptions> = {
     template: '@%%x',
     resolutions: { default: 1, low: 0.5 },
     fixedResolution: 'default',
+    sharpOptions: {},
 };
 
 export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, 'fix' | 'nomip'>
@@ -52,7 +56,7 @@ export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, '
                 sharpImage: sharp(asset.buffer),
             };
 
-            const { resolutions, fixedResolution } = options as Required<MipmapOptions>
+            const { resolutions, fixedResolution, sharpOptions } = options as Required<MipmapOptions>
                 || this.defaultOptions;
 
             const fixedResolutions = {
@@ -71,7 +75,7 @@ export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, '
 
                     image.resolution = largestResolution;
 
-                    processedImages = await mipmapSharp(image, resolutionHash, largestResolution);
+                    processedImages = await mipmapSharp(image, resolutionHash, largestResolution, sharpOptions);
                 }
                 else
                 {
@@ -79,7 +83,7 @@ export function mipmap(_options: MipmapOptions = {}): AssetPipe<MipmapOptions, '
 
                     processedImages = image.resolution === 1
                         ? [image]
-                        : processedImages = await mipmapSharp(image, fixedResolutions, largestResolution);
+                        : processedImages = await mipmapSharp(image, fixedResolutions, largestResolution, sharpOptions);
                 }
             }
             catch (error)

--- a/packages/assetpack/src/image/types.ts
+++ b/packages/assetpack/src/image/types.ts
@@ -1,0 +1,13 @@
+import type { ResizeOptions } from 'sharp';
+
+/**
+ * Options for sharp image processing.
+ */
+export interface SharpProcessingOptions
+{
+    /**
+     * Resize options for when sharp is used to process images.
+     * Note: width and height are not allowed here, they are defined by the pipe.
+     */
+    resize?: Omit<ResizeOptions, 'width' | 'height'>;
+}

--- a/packages/assetpack/src/image/utils/mipmapSharp.ts
+++ b/packages/assetpack/src/image/utils/mipmapSharp.ts
@@ -1,10 +1,24 @@
 import type { CompressImageData } from '../compress.js';
+import type { SharpProcessingOptions } from '../types.js';
 
+/**
+ * Generates mipmaps (multiple resolution versions) of an image using Sharp.
+ *
+ * This function creates different scaled versions of an image based on the provided
+ * resolution hash. It maintains the original image for the largest resolution and
+ * creates resized copies for smaller resolutions.
+ *
+ * @param image - The source image data containing Sharp image instance and format
+ * @param resolutionHash - Object mapping resolution names to their pixel values
+ * @param largestResolution - The maximum resolution value used as base for scaling
+ * @param sharpOptions - Sharp processing options including resize configuration
+ * @returns Promise resolving to array of CompressImageData objects, each representing a different resolution
+ */
 export async function mipmapSharp(
     image: CompressImageData,
     resolutionHash: {[x: string]: number},
-    largestResolution: number
-
+    largestResolution: number,
+    sharpOptions: SharpProcessingOptions
 ): Promise<CompressImageData[]>
 {
     const sharpImage = image.sharpImage;
@@ -33,7 +47,8 @@ export async function mipmapSharp(
                 resolution: resolutionHash[i],
                 sharpImage: sharpImage.clone().resize({
                     width: Math.round(width * scale),
-                    height: Math.round(height * scale)
+                    height: Math.round(height * scale),
+                    ...sharpOptions.resize,
                 })
             });
         }

--- a/packages/assetpack/src/texture-packer/packer/createTextureData.ts
+++ b/packages/assetpack/src/texture-packer/packer/createTextureData.ts
@@ -4,6 +4,13 @@ import { BuildReporter } from '../../core/index.js';
 
 import type { PackTexturesOptions, PixiRectData, TextureData } from './packTextures.js';
 
+/**
+ * Creates texture data for packing by processing individual textures and setting up a MaxRects packer.
+ *
+ * This function processes a collection of textures by scaling, trimming (if enabled), and preparing
+ * them for efficient packing into sprite sheets. It handles error cases by creating empty pixel
+ * textures as fallbacks and calculates trim offsets for proper sprite positioning.
+ */
 export async function createTextureData(options: Required<PackTexturesOptions>)
 {
     const packer = new MaxRectsPacker<PixiRectData>(options.width, options.height, options.padding, {
@@ -37,6 +44,7 @@ export async function createTextureData(options: Required<PackTexturesOptions>)
                 .resize({
                     width: newWidth,
                     height: newHeight,
+                    ...options.sharpOptions.resize,
                 });
 
             if (allowTrim)

--- a/packages/assetpack/src/texture-packer/packer/packTextures.ts
+++ b/packages/assetpack/src/texture-packer/packer/packTextures.ts
@@ -4,6 +4,7 @@ import { createTextures } from './createTextures.js';
 import { fitTextureToPacker } from './fitTextureToPacker.js';
 
 import type { MaxRectsPacker, Rectangle } from 'maxrects-packer';
+import type { SharpProcessingOptions } from '../../image/types.js';
 
 export interface PixiRectData extends Rectangle
 {
@@ -45,7 +46,7 @@ export interface PackTexturesOptions
     resolution?: number;
     nameStyle?: 'short' | 'relative';
     removeFileExtension?: boolean;
-    // prependFolderName
+    sharpOptions?: SharpProcessingOptions
 }
 
 interface PackTexturesResult
@@ -72,6 +73,7 @@ export async function packTextures(
         resolution: 1,
         nameStyle: 'relative',
         removeFileExtension: false,
+        sharpOptions: {},
         ..._options,
     };
 

--- a/packages/assetpack/src/texture-packer/texturePacker.ts
+++ b/packages/assetpack/src/texture-packer/texturePacker.ts
@@ -8,7 +8,9 @@ import type { PackTexturesOptions, TexturePackerFormat } from './packer/packText
 
 export interface TexturePackerOptions extends PluginOptions
 {
+    /** Options for the texture packer. */
     texturePacker?: Partial<PackTexturesOptions>;
+    /** Options for creating different resolutions of the sprite sheet. */
     resolutionOptions?: {
         /** A template for denoting the resolution of the images. */
         template?: string;


### PR DESCRIPTION
Adds the ability to pass Sharp processing options when processing images, allowing for more control over image manipulation.

This includes adding a `sharpOptions` option to the mipmap and texture packer plugins.

Closes: #127 #128
