### PR TITLE
fix: sdf/msdf function names in doc

### DIFF
--- a/packages/docs/docs/guide/pipes/webfont.mdx
+++ b/packages/docs/docs/guide/pipes/webfont.mdx
@@ -46,14 +46,14 @@ These plugins generate signed distance field (SDF) and multi-channel signed dist
 <ImageToggle image={'webfonts/webfont-sdf'} />
 
 ```js
-import { sdf, msdf } from "@assetpack/core/webfont";
+import { sdfFont, msdfFont } from "@assetpack/core/webfont";
 
 export default {
   ...
   pipes: [
     ...
-    sdf(),
-    msdf(),
+    sdfFont(),
+    msdfFont(),
   ],
 };
 ```


### PR DESCRIPTION
Fix a misspelling in the documentation: the exported function names in the webfont plugin should be `sdfFont / msdfFont`.
