### PR TITLE
fix: Fix maxrects-packer dependency on version 2.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26345,7 +26345,7 @@
     },
     "packages/assetpack": {
       "name": "@assetpack/core",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -26369,7 +26369,7 @@
         "glob": "^11.0.3",
         "gpu-tex-enc": "^1.2.5",
         "json5": "^2.2.3",
-        "maxrects-packer": "^2.7.3",
+        "maxrects-packer": "2.7.3",
         "merge": "^2.1.1",
         "minimatch": "10.0.3",
         "object-hash": "3.0.0",

--- a/packages/assetpack/package.json
+++ b/packages/assetpack/package.json
@@ -72,7 +72,7 @@
     "glob": "^11.0.3",
     "gpu-tex-enc": "^1.2.5",
     "json5": "^2.2.3",
-    "maxrects-packer": "^2.7.3",
+    "maxrects-packer": "2.7.3",
     "merge": "^2.1.1",
     "minimatch": "10.0.3",
     "object-hash": "3.0.0",


### PR DESCRIPTION
The most straightforward fix for the issue https://github.com/pixijs/assetpack/issues/150