### PR TITLE
chore: update docs

### DIFF
--- a/packages/docs/docs/guide/getting-started/installation.mdx
+++ b/packages/docs/docs/guide/getting-started/installation.mdx
@@ -31,6 +31,7 @@ AssetPack requires [Node.js](https://nodejs.org/en/) version 20+, please upgrade
 
 To set up AssetPack, you need to create a configuration file that defines what assets you want to optimise and how you want to optimise them.
 
+### For Node.js Versions < 20.19.0
 First create a `.assetpack.js` file in the root of your project. This file should export an object with the following properties:
 
 ```js
@@ -40,6 +41,29 @@ export default {
     output: './public/assets',
     pipes: [],
 };
+```
+
+### For Node.js Versions >= 20.19.0
+
+First create a `.assetpack.cjs` file in the root of your project. This file should export an object with the following properties:
+
+```js
+// .assetpack.cjs
+module.exports = {
+    entry: './raw-assets',
+    output: './public/assets',
+    pipes: [],
+};
+```
+
+You will need to update in the config path to your `package.json` scripts
+
+```json
+{
+  "scripts": {
+    "assetpack": "assetpack --config .assetpack.cjs"
+  }
+}
 ```
 
 To see the full list of configuration options, see the [API Reference](/docs/guide/configuration) page.


### PR DESCRIPTION
### Summary
The Assetpack setup steps break in Node.js versions >= 20.19.0.

The default config file `.assetpack.js` gets treated as a ES Module and the config object is wrapped, meaning that to access the config you would now need to call `config.default` in the Assetpack CLI.

Or you force the file to be treated as CommonJS (as indicated in the doc update)

### Changes
- Updated setup guide to include before and after Node.js v20.19.0 config changes