### PR TITLE
feat: pixiManifest: Src sorting options

### DIFF
--- a/packages/assetpack/src/manifest/pixiManifest.ts
+++ b/packages/assetpack/src/manifest/pixiManifest.ts
@@ -241,7 +241,8 @@ function collectAssets(
 
         // Set up sorting options
         const isAscendingSort = options.srcSortOptions?.order === 'ascending';
-        let sortOptions: Intl.CollatorOptions | undefined = undefined;
+        let sortOptions: Intl.CollatorOptions | undefined;
+
         if (options.srcSortOptions !== undefined) {
             sortOptions = {
                 numeric: options.srcSortOptions?.numeric ?? false,

--- a/packages/assetpack/test/manifest/Manifest.test.ts
+++ b/packages/assetpack/test/manifest/Manifest.test.ts
@@ -400,6 +400,106 @@ describe('Manifest', () => {
         });
     }, 30000);
 
+    it('should sort the order of the src array', async () => {
+        const testName = 'manifest-src-sort';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        const useCache = false;
+
+        createFolder(pkg, {
+            name: testName,
+            files: [],
+
+            folders: [
+                {
+                    name: 'defaultFolder',
+                    files: [],
+                    folders: [
+                        {
+                            name: 'mip',
+                            files: genSprites(3),
+                            folders: [],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const assetpack = new AssetPack({
+            entry: inputDir,
+            cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: useCache,
+            pipes: [
+                mipmap(),
+                compress({
+                    png: true,
+                    jpg: true,
+                    webp: true,
+                    avif: false,
+                    astc: true,
+                }),
+                pixiManifest({
+                    srcSortOptions: { order: 'ascending' },
+                }),
+            ],
+        });
+
+        await assetpack.run();
+
+        // load the manifest json
+        const manifest = sortObjectProperties(await fs.readJSONSync(`${outputDir}/manifest.json`)) as any;
+
+        expect(manifest.bundles[0]).toEqual({
+            name: 'default',
+            assets: [
+                {
+                    alias: ['defaultFolder/mip/sprite0.png'],
+                    src: [
+                        'defaultFolder/mip/sprite0.astc.ktx',
+                        'defaultFolder/mip/sprite0.png',
+                        'defaultFolder/mip/sprite0.webp',
+                        'defaultFolder/mip/sprite0@0.5x.astc.ktx',
+                        'defaultFolder/mip/sprite0@0.5x.png',
+                        'defaultFolder/mip/sprite0@0.5x.webp',
+                    ],
+                    data: {
+                        tags: {},
+                    },
+                },
+                {
+                    alias: ['defaultFolder/mip/sprite1.png'],
+                    src: [
+                        'defaultFolder/mip/sprite1.astc.ktx',
+                        'defaultFolder/mip/sprite1.png',
+                        'defaultFolder/mip/sprite1.webp',
+                        'defaultFolder/mip/sprite1@0.5x.astc.ktx',
+                        'defaultFolder/mip/sprite1@0.5x.png',
+                        'defaultFolder/mip/sprite1@0.5x.webp',
+                    ],
+                    data: {
+                        tags: {},
+                    },
+                },
+                {
+                    alias: ['defaultFolder/mip/sprite2.png'],
+                    src: [
+                        'defaultFolder/mip/sprite2.astc.ktx',
+                        'defaultFolder/mip/sprite2.png',
+                        'defaultFolder/mip/sprite2.webp',
+                        'defaultFolder/mip/sprite2@0.5x.astc.ktx',
+                        'defaultFolder/mip/sprite2@0.5x.png',
+                        'defaultFolder/mip/sprite2@0.5x.webp',
+                    ],
+                    data: {
+                        tags: {},
+                    },
+                },
+            ],
+        });
+    }, 30000);
+
     it('should try to add a shortcut to the names of each entry', async () => {
         const testName = 'manifest-shortcut';
         const inputDir = getInputDir(pkg, testName);

--- a/packages/docs/docs/guide/pipes/manifest.mdx
+++ b/packages/docs/docs/guide/pipes/manifest.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 ---
+
 import { ImageToggle } from '@site/src/components/ImageToggle';
 
 # Manifest
@@ -14,17 +15,6 @@ We believe this plugin is a must-have for any PixiJS project, as it simplifies t
 ## Example
 
 <ImageToggle image={'manifest/manifest-tags'} height={750} />
-
-{/* <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', paddingBottom: '24px' }}>
-    <img
-        src={'/assetpack/screenshots/manifest/manifest-tags.png'}
-        alt="Tags Example"
-        style={{
-            borderRadius: '12px',
-            boxShadow: '0 0 20px hsla(192, 84%, 40%, 0.5)',
-        }}
-    />
-</div> */}
 
 ```js
 import { pixiManifest } from "@assetpack/core/manifest";
@@ -48,13 +38,14 @@ export default {
 
 ## API
 
-| Option          | Type              | Description                                                                                    |
-| --------------- | ----------------- | ---------------------------------------------------------------------------------------------- |
-| output          | `string`          | The path to the manifest file.<br />Defaults to the output folder defined in your config.      |
-| createShortcuts | `boolean`         | Whether to create the shortest possible alias for an asset.<br />Defaults to `false`.          |
-| trimExtensions  | `boolean`         | Whether to trim the extensions from the asset aliases. <br />Defaults to `false`.              |
-| includeMetaData | `boolean`         | Whether to include the tags the asset has used in the manifest file. <br />Defaults to `true`. |
-| nameStyle       | `short\|relative` | The name style for the bundle names in the manifest file.<br />Defaults to `short`.            |
+| Option          | Type                                          | Description                                                                                                           |
+| --------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| output          | `string`                                      | The path to the manifest file.<br />Defaults to the output folder defined in your config.                             |
+| createShortcuts | `boolean`                                     | Whether to create the shortest possible alias for an asset.<br />Defaults to `false`.                                 |
+| trimExtensions  | `boolean`                                     | Whether to trim the extensions from the asset aliases. <br />Defaults to `false`.                                     |
+| includeMetaData | `boolean`                                     | Whether to include the tags the asset has used in the manifest file. <br />Defaults to `true`.                        |
+| nameStyle       | `short\|relative`                             | The name style for the bundle names in the manifest file.<br />Defaults to `short`.                                   |
+| srcSortOptions  | `object`, `(assetSrcs: string[]) => string[]` | A custom sort function or object configuration to sort the source order. <br />Defaults to `{ order: 'descending' }`. |
 
 ## Tags
 


### PR DESCRIPTION
# pixiManifest src array sorting options

Added options to control the sort of the src array. Using these options you can control the loading order of asset JSON files.

This can solve the problem of not loading all the relevant asset files when using multipack generated by texture-packer. PIXI seems to only read the first `src` entry per asset. By default the assets are sorted lexically in descending order. This presents an issue with multi packs since related multi packs are only defined in the first JSON file.

If the JSON with related multi packs is in the first position of the `src` array all assets are loaded as expected.

## Usage:

```JavaScript
...
pixiManifest({
  ...
  srcSortOptions: {
    numeric: true,
    order: "ascending",
  }
}),
...
```

## Output comparison
<img width="532" height="693" alt="image" src="https://github.com/user-attachments/assets/b08701ad-1b98-448c-bef8-96bac3d5952e" />
