### PR TITLE
feat: Adds file size to asset manifest

### DIFF
--- a/packages/assetpack/src/spine/spineAtlasManifestMod.ts
+++ b/packages/assetpack/src/spine/spineAtlasManifestMod.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { type PixiManifest } from 'src/manifest/pixiManifest.js';
 import { findAssets, path } from '../core/index.js';
 import { AtlasView } from './AtlasView.js';
 
@@ -73,11 +74,13 @@ export function spineAtlasManifestMod(_options: SpineManifestOptions = {}): Asse
     };
 }
 
-function findAndRemoveManifestAsset(manifest: any, assetPath: string) {
+function findAndRemoveManifestAsset(manifest: PixiManifest, assetPath: string) {
     for (let i = 0; i < manifest.bundles.length; i++) {
         const assets = manifest.bundles[i].assets;
 
-        const manifestAsset = assets.find((asset: { src: string[] }) => asset.src.includes(assetPath));
+        const manifestAsset = assets.find((asset) => {
+            return asset.src.find((src) => (typeof src === 'string' ? src : src.src) === assetPath);
+        });
 
         if (manifestAsset) {
             assets.splice(assets.indexOf(manifestAsset), 1);

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -52,8 +52,8 @@ const updatePackageVersion = async (packagePath, newVersion) => {
 const updatePackageLockVersion = async (packageLockPath, newVersion) => {
     const packageLockJson = await readJsonFile(packageLockPath);
 
-    if (packageLockJson['packages/assetpack']) {
-        packageLockJson['packages/assetpack'].version = newVersion;
+    if (packageLockJson.packages && packageLockJson.packages['packages/assetpack']) {
+        packageLockJson.packages['packages/assetpack'].version = newVersion;
     }
 
     await writeJsonFile(packageLockPath, packageLockJson);


### PR DESCRIPTION
Adds the ability to include file sizes in the asset manifest.

- Updates manifest structure to include file sizes (gzipped or raw)
- Adds option to enable/disable file size inclusion.
- Adds logic to compute gzipped file sizes during manifest creation.
- Handles cases where file size retrieval fails gracefully.
- Modifies how assets are identified in the manifest to handle the new file size object.
