### PR TITLE
fix: texturePacker.textureFormat export only .png files

### DIFF
--- a/packages/assetpack/src/texture-packer/packer/createJsons.ts
+++ b/packages/assetpack/src/texture-packer/packer/createJsons.ts
@@ -2,7 +2,7 @@ import { path } from '../../core/index.js';
 import { createName } from './createTextures.js';
 import { detectAnimations } from './detectAnimations.js';
 
-import type { PixiPacker } from './packTextures.js';
+import type { PixiPacker, TexturePackerFormat } from './packTextures.js';
 
 function convertName(pth: string, nameStyle: 'short' | 'relative', removeFileExtension = false) {
     const name = nameStyle === 'short' ? path.basename(pth) : pth;
@@ -17,7 +17,7 @@ export function createJsons(
     options: {
         textureName: string;
         resolution: number;
-        textureFormat: 'png' | 'jpg';
+        textureFormat: TexturePackerFormat;
         nameStyle: 'short' | 'relative';
         removeFileExtension: boolean;
         autodetectAnimations?: boolean;

--- a/packages/assetpack/src/texture-packer/packer/createTextures.ts
+++ b/packages/assetpack/src/texture-packer/packer/createTextures.ts
@@ -50,7 +50,16 @@ export async function createTextures(
             },
         }).composite(compositeOptions);
 
-        compositeTexture = options.textureFormat === 'png' ? compositeTexture.png() : compositeTexture.jpeg();
+        switch (options.textureFormat) {
+            case 'webp':
+                compositeTexture = compositeTexture.webp();
+                break;
+            case 'jpg':
+                compositeTexture = compositeTexture.jpeg();
+                break;
+            default:
+                compositeTexture = compositeTexture.png();
+        }
 
         texturePromises.push(
             compositeTexture.toBuffer().then((buffer) => ({

--- a/packages/assetpack/src/texture-packer/packer/packTextures.ts
+++ b/packages/assetpack/src/texture-packer/packer/packTextures.ts
@@ -13,7 +13,7 @@ export interface PixiRectData extends Rectangle {
 
 export type PixiPacker = MaxRectsPacker<PixiRectData>;
 
-export type TexturePackerFormat = 'png' | 'jpg';
+export type TexturePackerFormat = 'png' | 'jpg' | 'webp';
 
 export interface TextureData {
     buffer: Buffer;

--- a/packages/assetpack/src/texture-packer/texturePacker.ts
+++ b/packages/assetpack/src/texture-packer/texturePacker.ts
@@ -114,7 +114,7 @@ export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<Te
                 }),
             );
 
-            let textureFormat: TexturePackerFormat = texturePacker.textureFormat;
+            let textureFormat: TexturePackerFormat = texturePacker.textureFormat ?? 'png';
 
             if (asset.metaData[this.tags!.jpg]) textureFormat = 'jpg'; // if tags exist force .jpg anyway
 

--- a/packages/assetpack/src/texture-packer/texturePacker.ts
+++ b/packages/assetpack/src/texture-packer/texturePacker.ts
@@ -114,7 +114,9 @@ export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<Te
                 }),
             );
 
-            const textureFormat = (asset.metaData[this.tags!.jpg] ? 'jpg' : 'png') as TexturePackerFormat;
+            let textureFormat: TexturePackerFormat = texturePacker.textureFormat;
+
+            if (asset.metaData[this.tags!.jpg]) textureFormat = 'jpg'; // if tags exist force .jpg anyway
 
             const texturePackerOptions = {
                 ...texturePacker,


### PR DESCRIPTION
Fixed the problem with .json only linking to .png file.

Also added .webp support.