### PR TITLE
fix: Update buildTime when watch triggers

### DIFF
--- a/packages/assetpack/src/core/AssetWatcher.ts
+++ b/packages/assetpack/src/core/AssetWatcher.ts
@@ -152,6 +152,7 @@ export class AssetWatcher {
                 }
 
                 this._timeoutId = setTimeout(() => {
+                    BuildReporter.report({ type: 'buildWatchChange' });
                     void this._updateAssets();
                     this._timeoutId = undefined;
 

--- a/packages/assetpack/src/core/logger/Reporter.ts
+++ b/packages/assetpack/src/core/logger/Reporter.ts
@@ -67,7 +67,9 @@ export class Reporter {
                 stopProgress();
                 resetWindow();
                 persistMessage(
-                    chalk.green.bold(`✔ AssetPack Completed in ${prettifyTime(Math.max(Date.now() - this._buildTime, 0))}`),
+                    chalk.green.bold(
+                        `✔ AssetPack Completed in ${prettifyTime(Math.max(Date.now() - this._buildTime, 0))}`,
+                    ),
                 );
                 break;
             case 'buildFailure':

--- a/packages/assetpack/src/core/logger/Reporter.ts
+++ b/packages/assetpack/src/core/logger/Reporter.ts
@@ -12,7 +12,7 @@ export interface LogEvent {
 }
 
 export interface BuildEvent {
-    type: 'buildStart' | 'buildProgress' | 'buildSuccess' | 'buildFailure';
+    type: 'buildStart' | 'buildWatchChange' | 'buildProgress' | 'buildSuccess' | 'buildFailure';
     phase?: 'start' | 'delete' | 'transform' | 'post' | 'finish';
     message?: string;
 }
@@ -42,6 +42,11 @@ export class Reporter {
 
                 break;
             }
+            case 'buildWatchChange': {
+                this._buildTime = Date.now();
+
+                break;
+            }
             case 'buildProgress': {
                 if (logLevelFilter < LogLevel.info) {
                     break;
@@ -62,7 +67,7 @@ export class Reporter {
                 stopProgress();
                 resetWindow();
                 persistMessage(
-                    chalk.green.bold(`✔ AssetPack Completed in ${prettifyTime(Date.now() - this._buildTime)}`),
+                    chalk.green.bold(`✔ AssetPack Completed in ${prettifyTime(Math.max(Date.now() - this._buildTime, 0))}`),
                 );
                 break;
             case 'buildFailure':


### PR DESCRIPTION
Currently if you have a long running `watch` from asset pack it always counts from the initial build's start time. This can make the time it took look ridiculous and not be very useful.

Before:
<img width="319" height="42" alt="image" src="https://github.com/user-attachments/assets/fab33169-a374-4103-a433-b0965e41448a" />

After:
<img width="299" height="55" alt="image" src="https://github.com/user-attachments/assets/9397de8b-7ba2-4a93-97d2-adeb3ee6ad2b" />

Here I attempt to correct that.

## Steps to reproduce:

1. Run `assetpack -w` on a directory with an [assetpack config file in](https://pixijs.io/assetpack/docs/guide/getting-started/installation/#setup)
2. Wait a few seconds (5-10 is enough)
3. Make a change to a file in the watched directory