### PR TITLE
fix: Animation detection key for folder-based frame organization

### DIFF
--- a/packages/assetpack/src/texture-packer/packer/detectAnimations.ts
+++ b/packages/assetpack/src/texture-packer/packer/detectAnimations.ts
@@ -6,7 +6,7 @@ export function detectAnimations(frames: { [key: string]: any }): { [key: string
     const suffixRegex = /(?:[-_]?)(\d+)$/;
 
     const frameGroups = frameNames.reduce<Record<string, string[]>>((acc, item) => {
-        const key = path.trimExt(item).replace(suffixRegex, '');
+        const key = path.trimExt(item).replace(suffixRegex, '').replace(/\/$/, '');
 
         // if the key doesn't have a number suffix, don't add it
         if (key === path.trimExt(item)) return acc;

--- a/packages/assetpack/test/texture-packer/texturePacker.test.ts
+++ b/packages/assetpack/test/texture-packer/texturePacker.test.ts
@@ -686,6 +686,59 @@ describe('Texture Packer', () => {
         mockWarn.mockRestore();
     });
 
+    it('should detect animations from numbered files in subdirectories without trailing slash', async () => {
+        const testName = 'tp-anim-subdir';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        const sprites: File[] = [];
+
+        for (let i = 0; i < 4; i++) {
+            sprites.push({
+                name: `${i}.png`,
+                content: assetPath(`image/sp-${i + 1}.png`),
+            });
+        }
+
+        createFolder(pkg, {
+            name: testName,
+            files: [],
+            folders: [
+                {
+                    name: 'sprites{tps}',
+                    files: [],
+                    folders: [
+                        {
+                            name: 'foo',
+                            files: sprites,
+                            folders: [],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const assetpack = new AssetPack({
+            entry: inputDir,
+            cacheLocation: getCacheDir(pkg, testName),
+            output: outputDir,
+            cache: false,
+            pipes: [
+                texturePacker({
+                    resolutionOptions: {
+                        resolutions: { default: 1 },
+                    },
+                }),
+            ],
+        });
+
+        await assetpack.run();
+
+        const sheet = fs.readJSONSync(`${outputDir}/sprites.json`);
+
+        expect(sheet.animations['foo']).toEqual(['foo/0.png', 'foo/1.png', 'foo/2.png', 'foo/3.png']);
+    });
+
     it('should handle smaller than 3x3 textures if trimming is enabled', async () => {
         const testName = 'tp-small-trim';
         const inputDir = getInputDir(pkg, testName);


### PR DESCRIPTION
Currently, animation detection assumes frames are always named with a numbered suffix (e.g. bar0.png, bar1.png). This works well for flat structures, but breaks down when frames are organized into their own subfolder — a pattern where the folder name itself should become the animation key.

### Flat structures

```
foo/
├─ bar0.png
├─ bar1.png
├─ bar2.png
├─ bar3.png
├─ baz.png

// Animation key → `foo/bar`
```

### Animation subfolder

```
foo/
├─ bar/
│  ├─ 0.png
│  ├─ 1.png
│  ├─ 2.png
│  ├─ 3.png
├─ baz.png

// (previously) Animation key → `foo/bar/`
// (this PR)  Animation key → `foo/bar`
```

In my scenario I tend to prefer this sort of structure, so this keeps animation frames cleanly isolated from non-animation assets and makes it easier to manage large spritesheets with many animations/frames.
